### PR TITLE
fix: add Image role for TalkBack on ImageView elements

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/readonly/ImageRenderer.java
@@ -22,6 +22,10 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.ConstraintSet;
 import androidx.fragment.app.FragmentManager;
 
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.core.view.AccessibilityDelegateCompat;
+
 import io.adaptivecards.R;
 import io.adaptivecards.objectmodel.BaseCardElement;
 import io.adaptivecards.objectmodel.HeightType;
@@ -330,6 +334,15 @@ public class ImageRenderer extends BaseCardElementRenderer
 
         ImageView imageView = new ImageView(context);
         imageView.setContentDescription(image.GetAltText());
+
+        // Fix: Set Image role for TalkBack (#490, #375)
+        ViewCompat.setAccessibilityDelegate(imageView, new AccessibilityDelegateCompat() {
+            @Override
+            public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+                super.onInitializeAccessibilityNodeInfo(host, info);
+                info.setRoleDescription("Image");
+            }
+        });
 
         int backgroundColor = getBackgroundColorFromHexCode(image.GetBackgroundColor());
 


### PR DESCRIPTION
## Summary
TalkBack was not announcing the role of images when navigating Adaptive Cards.

## Changes
- Added `AccessibilityDelegateCompat` to `ImageRenderer.java` that sets `roleDescription="Image"` on ImageView elements
- This ensures TalkBack announces "Image" as part of the element description

## Issues
- Fixes hggzm/Teams-AdaptiveCards-Mobile#17 ([upstream#490])
- Fixes hggzm/Teams-AdaptiveCards-Mobile#21 ([upstream#375])

## Testing
- Enable TalkBack on Android device
- Navigate to a card with images
- Verify TalkBack announces "Image" role for each image element