### PR TITLE
fix: prevent TalkBack from announcing both Link and Button for OpenUrl

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/action/ActionElementRenderer.java
@@ -15,6 +15,9 @@ import android.widget.Button;
 import android.widget.LinearLayout;
 
 import androidx.appcompat.widget.TooltipCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
+import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.fragment.app.FragmentManager;
 
 import io.adaptivecards.R;
@@ -172,7 +175,17 @@ public class ActionElementRenderer extends BaseActionElementRenderer
         }
 
         if (baseActionElement.GetElementType() == ActionType.OpenUrl) {
-            button.setContentDescription(Util.getOpenUrlAnnouncement(context, baseActionElement.GetTitle()));
+            // Fix: Use roleDescription instead of appending "link" to contentDescription (#492)
+            // This prevents TalkBack from announcing both "link" (from text) and "Button" (from widget)
+            button.setContentDescription(baseActionElement.GetTitle());
+            ViewCompat.setAccessibilityDelegate(button, new AccessibilityDelegateCompat() {
+                @Override
+                public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+                    super.onInitializeAccessibilityNodeInfo(host, info);
+                    info.setClassName("");
+                    info.setRoleDescription("Link");
+                }
+            });
         }
 
         viewGroup.addView(button);


### PR DESCRIPTION
## Summary
OpenUrl actions caused TalkBack to announce both "link" (from contentDescription) and "Button" (from widget class), creating a confusing double-role announcement.

## Changes
- `ActionElementRenderer.java`: Use `roleDescription="Link"` via AccessibilityDelegate instead of appending "link" to contentDescription
- Clear the Button className so TalkBack only announces the Link role

## Issues
- Fixes hggzm/Teams-AdaptiveCards-Mobile#16 ([upstream#492])

## Testing
- Navigate to a card with OpenUrl actions using TalkBack
- Verify it announces "\<title\>, Link" instead of "\<title\> link, Button"