### PR TITLE
fix: prevent RadioGroup from aggregating child labels for TalkBack

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -223,6 +223,10 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
         renderedCard.registerInputHandler(radioGroupInputHandler, renderArgs.getContainerCardId());
         InputUtils.updateInputHandlerInputWatcher(radioGroupInputHandler);
 
+        // Fix: Prevent RadioGroup from aggregating all child labels for TalkBack (#483)
+        // Each individual RadioButton should be announced separately
+        radioGroup.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+
         return radioGroup;
     }
 


### PR DESCRIPTION
## Summary
When TalkBack focus moved to a RadioGroup, it read all radio button labels concatenated, overwhelming the user.

## Changes
- `ChoiceSetInputRenderer.java`: Set `IMPORTANT_FOR_ACCESSIBILITY_NO` on the RadioGroup container so each individual RadioButton is announced separately

## Issues
- Fixes hggzm/Teams-AdaptiveCards-Mobile#18 ([upstream#483])

## Testing
- Navigate to a card with radio button choices
- Verify TalkBack reads each radio button individually, not all at once