### PR TITLE
fix: correct TalkBack dropdown item count to exclude hidden placeholder

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -308,7 +308,8 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
                 View spinnerView = super.getDropDownView(position, convertView, parent);
                 TextView spinnerTextView = (TextView) spinnerView;
 
-                String talkbackAnnouncement = context.getResources().getString(R.string.spinner_talkback_announcement, m_items.get(position), position+1, m_items.size());
+                // Fix: Use getCount() instead of m_items.size() to exclude hidden placeholder (#466)
+                String talkbackAnnouncement = context.getResources().getString(R.string.spinner_talkback_announcement, m_items.get(position), position+1, getCount());
                 spinnerTextView.setContentDescription(talkbackAnnouncement);
                 return spinnerView;
             }


### PR DESCRIPTION
## Summary
TalkBack announced incorrect item count for dropdown spinners because
`m_items.size()` included the hidden placeholder.

## Fix
Changed to `getCount()` which correctly excludes the placeholder item.

## Files Changed
- `ChoiceSetInputRenderer.java` — 1 file, +2/-1 lines

## Related Issues
- Upstream #466