### PR TITLE
fix: prevent RadioGroup from aggregating child labels for TalkBack

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -223,6 +223,10 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
         renderedCard.registerInputHandler(radioGroupInputHandler, renderArgs.getContainerCardId());
         InputUtils.updateInputHandlerInputWatcher(radioGroupInputHandler);
 
+        // Fix: Prevent RadioGroup from aggregating all child labels for TalkBack (#483)
+        // Each individual RadioButton should be announced separately
+        radioGroup.setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_NO);
+
         return radioGroup;
     }
 


### PR DESCRIPTION
## Summary
When focus moved to a RadioGroup, TalkBack read all radio button labels
concatenated into one announcement.

## Fix
Set `IMPORTANT_FOR_ACCESSIBILITY_NO` on the RadioGroup so each RadioButton
is announced individually when focused.

## Files Changed
- `ChoiceSetInputRenderer.java` — 1 file, +4 lines

## Related Issues
- Upstream #483