### PR TITLE
fix(android): correct selected state for Spinner dropdown items (#110)

### DIFF
--- a/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
+++ b/source/android/adaptivecards/src/main/java/io/adaptivecards/renderer/input/ChoiceSetInputRenderer.java
@@ -310,6 +310,7 @@ public class ChoiceSetInputRenderer extends BaseCardElementRenderer
 
                 String talkbackAnnouncement = context.getResources().getString(R.string.spinner_talkback_announcement, m_items.get(position), position+1, m_items.size());
                 spinnerTextView.setContentDescription(talkbackAnnouncement);
+                spinnerView.setSelected(position == ((Spinner) parent).getSelectedItemPosition());
                 return spinnerView;
             }
 


### PR DESCRIPTION
## Problem
TalkBack announces "Selected" for non-selected items in Spinner dropdown (compact ChoiceSet). All items get announced as selected regardless of their actual state.

## Fix
Set spinnerView.setSelected() in getDropDownView() based on whether the item position matches the Spinner current selection.

## Issue
Fixes upstream microsoft/Teams-AdaptiveCards-Mobile#110

## Files Changed
- ChoiceSetInputRenderer.java (+1 line)