### PR TITLE
docs(proxy-pr-log): swift-swiftharness-bridge initial drop (#48) pending

### DIFF
--- a/docs/PROXY_PR_LOG.md
+++ b/docs/PROXY_PR_LOG.md
@@ -171,3 +171,10 @@ Toggle test: initial=54 elements -> expanded=56 -> collapsed=54 (round-trip conf
 | 41 | swiftharness Swift-on-Windows kit drop | proxy/feat-swift-swiftharness-bridge | n/a (proxy-only) | n/a | pending |
 
 **Status:** pending. Vendored `hggz/swiftharness` snapshot as `source/ios-swift-swiftharness/`: four library targets (Core, Tools, Commands, Session, total ~20 .swift files), proxy-only CI gating `swift build -c debug` plus a Flavor A symbol-check example (`examples/adaptivecards-swiftharness-demo/`) that round-trips the canonical AdaptiveCards.io "Hello World" sample through the vendored `SessionStore` actor. Six distinct kit symbols exercised. `smoke.ps1` exits non-zero unless `PASS adaptivecards-swiftharness-roundtrip` lands on stdout. No edits to existing ObjC/Java/C++ shipping code. Foundation-only — manifest carries zero SSH URLs.
+## Swift-on-Windows experimental bridges (proxy-only)
+
+| # | Issue | Proxy Branch | Clean Branch | Upstream PR | Fix |
+|---|-------|-------------|-------------|------------|-----|
+| 41 | swiftharness Swift-on-Windows kit drop | proxy/feat-swift-swiftharness-bridge | n/a (proxy-only) | n/a | pending |
+
+**Status:** pending. Vendored `hggz/swiftharness` snapshot as `source/ios-swift-swiftharness/`: four library targets (Core, Tools, Commands, Session, total ~20 .swift files), proxy-only CI gating `swift build -c debug` plus a Flavor A symbol-check example (`examples/adaptivecards-swiftharness-demo/`) that round-trips the canonical AdaptiveCards.io "Hello World" sample through the vendored `SessionStore` actor. Six distinct kit symbols exercised. `smoke.ps1` exits non-zero unless `PASS adaptivecards-swiftharness-roundtrip` lands on stdout. No edits to existing ObjC/Java/C++ shipping code. Foundation-only — manifest carries zero SSH URLs.

--- a/docs/PROXY_PR_LOG.md
+++ b/docs/PROXY_PR_LOG.md
@@ -171,10 +171,3 @@ Toggle test: initial=54 elements -> expanded=56 -> collapsed=54 (round-trip conf
 | 41 | swiftharness Swift-on-Windows kit drop | proxy/feat-swift-swiftharness-bridge | n/a (proxy-only) | n/a | pending |
 
 **Status:** pending. Vendored `hggz/swiftharness` snapshot as `source/ios-swift-swiftharness/`: four library targets (Core, Tools, Commands, Session, total ~20 .swift files), proxy-only CI gating `swift build -c debug` plus a Flavor A symbol-check example (`examples/adaptivecards-swiftharness-demo/`) that round-trips the canonical AdaptiveCards.io "Hello World" sample through the vendored `SessionStore` actor. Six distinct kit symbols exercised. `smoke.ps1` exits non-zero unless `PASS adaptivecards-swiftharness-roundtrip` lands on stdout. No edits to existing ObjC/Java/C++ shipping code. Foundation-only — manifest carries zero SSH URLs.
-## Swift-on-Windows experimental bridges (proxy-only)
-
-| # | Issue | Proxy Branch | Clean Branch | Upstream PR | Fix |
-|---|-------|-------------|-------------|------------|-----|
-| 41 | swiftharness Swift-on-Windows kit drop | proxy/feat-swift-swiftharness-bridge | n/a (proxy-only) | n/a | pending |
-
-**Status:** pending. Vendored `hggz/swiftharness` snapshot as `source/ios-swift-swiftharness/`: four library targets (Core, Tools, Commands, Session, total ~20 .swift files), proxy-only CI gating `swift build -c debug` plus a Flavor A symbol-check example (`examples/adaptivecards-swiftharness-demo/`) that round-trips the canonical AdaptiveCards.io "Hello World" sample through the vendored `SessionStore` actor. Six distinct kit symbols exercised. `smoke.ps1` exits non-zero unless `PASS adaptivecards-swiftharness-roundtrip` lands on stdout. No edits to existing ObjC/Java/C++ shipping code. Foundation-only — manifest carries zero SSH URLs.

--- a/docs/PROXY_PR_LOG.md
+++ b/docs/PROXY_PR_LOG.md
@@ -163,3 +163,11 @@ Toggle test: initial=54 elements -> expanded=56 -> collapsed=54 (round-trip conf
 **Fix:**
 - iOS: Set `ACRView.accessibilityLabel` from card speak property via `GetSpeak()` with full null-safety guards
 - Android: Set `contentDescription` from speak; set `accessibilityLiveRegion = POLITE`
+
+## Swift-on-Windows experimental bridges (proxy-only)
+
+| # | Issue | Proxy Branch | Clean Branch | Upstream PR | Fix |
+|---|-------|-------------|-------------|------------|-----|
+| 41 | swiftharness Swift-on-Windows kit drop | proxy/feat-swift-swiftharness-bridge | n/a (proxy-only) | n/a | pending |
+
+**Status:** pending. Vendored `hggz/swiftharness` snapshot as `source/ios-swift-swiftharness/`: four library targets (Core, Tools, Commands, Session, total ~20 .swift files), proxy-only CI gating `swift build -c debug` plus a Flavor A symbol-check example (`examples/adaptivecards-swiftharness-demo/`) that round-trips the canonical AdaptiveCards.io "Hello World" sample through the vendored `SessionStore` actor. Six distinct kit symbols exercised. `smoke.ps1` exits non-zero unless `PASS adaptivecards-swiftharness-roundtrip` lands on stdout. No edits to existing ObjC/Java/C++ shipping code. Foundation-only — manifest carries zero SSH URLs.


### PR DESCRIPTION
Adds a single row + status paragraph to ``docs/PROXY_PR_LOG.md`` for the swift-swiftharness-bridge initial drop landed at hggz:proxy/feat-swift-swiftharness-bridge against hggzm/Teams-AdaptiveCards-Mobile#48.

| # | Issue | Proxy Branch | Status |
|---|-------|-------------|--------|
| 41 | swiftharness Swift-on-Windows kit drop | proxy/feat-swift-swiftharness-bridge | pending |

Status will move from `pending` to `green` once #48 merges (its Windows MSVC CI is already green — both compile floor and runtime symbol-check steps land `PASS adaptivecards-swiftharness-roundtrip` on stdout).