### PR TITLE
feat(swift-swiftsync-bridge): initial proxy drop

### DIFF
--- a/.github/workflows/swift-swiftsync-bridge-gate.yml
+++ b/.github/workflows/swift-swiftsync-bridge-gate.yml
@@ -1,0 +1,78 @@
+# proxy-only — do NOT cherry-pick this workflow to any clean/* branch
+# or to any PR targeting microsoft/main. Lives only on:
+#   hggz/AdaptiveCards-Mobile  : proxy/feat-swift-swiftsync-bridge, proxy/integration
+#   hggzm/Teams-AdaptiveCards-Mobile : proxy/integration (after merge)
+name: swift-swiftsync-bridge gate
+
+on:
+  push:
+    branches:
+      - 'proxy/feat-swift-swiftsync-bridge'
+      - 'proxy/integration'
+    paths:
+      - 'source/ios-swift-swiftsync/**'
+      - '.github/workflows/swift-swiftsync-bridge-gate.yml'
+  pull_request:
+    branches: [ 'proxy/integration' ]
+    paths:
+      - 'source/ios-swift-swiftsync/**'
+      - '.github/workflows/swift-swiftsync-bridge-gate.yml'
+
+jobs:
+  windows-msvc:
+    name: Windows MSVC / Swift 6.3.1
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      # The proxy/integration tree carries a tracked file with a colon in its
+      # name ('t-Path C:\Users\hugogonzalez\teams_branch_diffs.txt'), which is
+      # invalid on NTFS. actions/checkout@v4 runs `git checkout`, which rejects
+      # the path with exit 128 regardless of sparse-checkout. Workaround: do the
+      # clone manually with core.protectNTFS=false so git on Windows ignores the
+      # NTFS-safety check on that one path. Everything we build
+      # (source/ios-swift-swiftsync/ + this workflow) is safe.
+      - name: Manual checkout with protectNTFS=false
+        env:
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
+        run: |
+          git config --global core.protectNTFS false
+          git init .
+          git remote add origin "https://github.com/$env:REPO.git"
+          git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin $env:REF
+          git checkout --progress --force $env:REF
+          git rev-parse HEAD
+
+      - name: Install Swift 6.3.1
+        uses: compnerd/gha-setup-swift@main
+        with:
+          # compnerd/gha-setup-swift wants the release-branch name in
+          # swift-version (NOT just the version number) and the corresponding
+          # RELEASE tag in swift-build.
+          swift-version: "swift-6.3.1-release"
+          swift-build:   "6.3.1-RELEASE"
+
+      - name: swift --version
+        run: swift --version
+
+      # ----------------------------------------------------------------
+      # Step 1 (compile floor): the vendored kit must build clean.
+      # SwiftSyncCore is pure Foundation — no zlib, no extra flags.
+      # ----------------------------------------------------------------
+      - name: swift build -c debug (kit)
+        working-directory: source/ios-swift-swiftsync
+        run: |
+          swift build -c debug
+          if ($LASTEXITCODE -ne 0) { throw "kit build failed" }
+
+      # ----------------------------------------------------------------
+      # Step 2 (link + execute): the symbol-check demo must build, run,
+      # and emit `PASS adaptivecards-swiftsync-roundtrip`.
+      # ----------------------------------------------------------------
+      - name: smoke (build + run + assert PASS)
+        working-directory: source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo
+        run: |
+          ./smoke.ps1
+          if ($LASTEXITCODE -ne 0) { throw "smoke failed" }

--- a/source/ios-swift-swiftsync/.gitattributes
+++ b/source/ios-swift-swiftsync/.gitattributes
@@ -1,0 +1,11 @@
+# Force LF on all text so Linux/Windows CI parity stays stable, regardless of
+# the platform a contributor commits from.
+* text=auto eol=lf
+
+*.swift   text eol=lf
+*.json    text eol=lf
+*.md      text eol=lf
+*.yml     text eol=lf
+*.yaml    text eol=lf
+*.sh      text eol=lf
+*.ps1     text eol=lf

--- a/source/ios-swift-swiftsync/Package.swift
+++ b/source/ios-swift-swiftsync/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:6.0
+//
+// source/ios-swift-swiftsync/Package.swift
+//
+// Vendored snapshot of the SwiftSyncCore engine from hggz/swiftsync, dropped
+// alongside the production Adaptive Cards mobile SDK as an experimental,
+// proxy-only parallel Swift surface. It touches none of the existing
+// ObjC/Java/C++ code.
+//
+// SwiftSyncCore is a general-purpose, pure-Foundation directory-sync engine
+// (a minimalist rsync-style recursive copy). It has NO external package
+// dependencies and imports only Foundation, so it builds unchanged on Apple
+// platforms, Linux, and Windows. There are deliberately no private SSH-alias
+// dependency URLs and no Apple-only imports.
+
+import PackageDescription
+
+// `platforms` only narrows minimum versions for Apple platforms. Linux,
+// Windows, Android, and any other Swift-supported target build with no
+// platform clause — so we deliberately do NOT restrict to Apple here.
+let package = Package(
+    name: "SwiftSyncCore",
+    platforms: [
+        .iOS(.v15), .macOS(.v12), .tvOS(.v15),
+        .watchOS(.v8), .visionOS(.v1),
+    ],
+    products: [
+        .library(name: "SwiftSyncCore", targets: ["SwiftSyncCore"]),
+    ],
+    targets: [
+        .target(name: "SwiftSyncCore"),
+    ]
+)

--- a/source/ios-swift-swiftsync/README.md
+++ b/source/ios-swift-swiftsync/README.md
@@ -1,0 +1,56 @@
+# ios-swift-swiftsync — experimental, proxy-only Swift bridge
+
+This subfolder is a **vendored snapshot of the `SwiftSyncCore` engine** from the
+`hggz/swiftsync` Swift-on-Windows kit, dropped alongside the production Adaptive
+Cards mobile SDK as an **experimental, proxy-only parallel Swift surface**. It is
+not for upstream and it touches **none** of the existing ObjC (`source/ios/`),
+Java (`source/android/`), or C++ (`source/shared/cpp/`) code.
+
+- **Vendored as of:** 2026-06-17.
+- **License:** this snapshot inherits the repository-root **MIT** license. There
+  is no nested `LICENSE` file and no per-file license headers.
+
+## What it is
+
+`SwiftSyncCore` is a general-purpose, pure-Foundation **directory-sync engine** —
+a minimalist rsync-style recursive copy with an exhaustively-tested "needs copy?"
+decision (destination missing / size differs / source newer), atomic temp+rename
+byte copy (never truncating in place), per-entry error capture that never aborts
+a run, optional `--exclude` globbing, optional `--delete`, and optional symlink
+following. In this bridge it is used headlessly: a host can drive `Syncer`
+directly to move Adaptive Card JSON payloads between directories.
+
+## Substrate
+
+**None.** Unlike the NIO-backed bridges, `SwiftSyncCore` has **zero external
+package dependencies** and imports only `Foundation`. There are no
+`git@github.com-hggz:...` URLs in `Package.swift`, no vcpkg/zlib requirement, and
+no Apple-only imports — the terminal/progress UI layer of the original kit
+(which used `import Darwin`/`Glibc`/`WinSDK`) is intentionally omitted because the
+bridge surface is the headless engine.
+
+## Build (Windows MSVC)
+
+```pwsh
+swift build -c debug
+```
+
+## Runtime symbol-check demo
+
+`examples/adaptivecards-swiftsync-demo/` is a separate SwiftPM package that
+path-deps this snapshot and proves the vendored symbols actually link and run
+end-to-end (flavor A — "store / round-trip"): it syncs the canonical
+adaptivecards.io "Hello World" card from a temp source directory into a temp
+destination directory via the public `Syncer` API, reads it back, and asserts the
+bytes are identical, printing `PASS adaptivecards-swiftsync-roundtrip`.
+
+### Symbols exercised
+
+The demo calls these public `SwiftSyncCore` symbols:
+
+- `Syncer(source:destination:options:)` and `Syncer.run()` — drive the recursive sync.
+- `Syncer.Options(preservePermissions:exclude:delete:copyLinks:)` — configure it.
+- `SyncSummary` / `SyncStats.filesCopied` — assert the tally.
+- `FSOps.stat(at:)` and `FSOps.decideCopy(source:destination:)` — confirm the
+  post-sync decision is `.skip` (destination already current).
+- `HumanSize.string(_:)` — format the transferred byte count for the log line.

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/DeletionPlan.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/DeletionPlan.swift
@@ -1,0 +1,28 @@
+/// Decides which destination entries should be removed when `--delete` is in
+/// effect: those present at the destination but **absent from the source**.
+/// Pure and total — no I/O — because deletion is the single most dangerous
+/// operation in the tool and its decision must be exhaustively unit-tested.
+///
+/// Two safety rules are baked in:
+/// - An entry that exists in the source is never deleted.
+/// - An entry that matches the active exclude patterns is never deleted, so
+///   `--exclude`d paths at the destination are *protected* rather than purged.
+public enum DeletionPlan {
+    /// Returns the destination-relative paths to delete, given the set of
+    /// relative paths that exist in the source, every relative path found at the
+    /// destination, and the active exclude patterns.
+    ///
+    /// The result preserves the order of `destinationRelativePaths`; the caller
+    /// is responsible for removing deepest paths first so a directory is empty
+    /// (and individually counted) before it is removed.
+    public static func entriesToDelete(
+        sourceRelativePaths: Set<String>,
+        destinationRelativePaths: [String],
+        exclude: [String] = []
+    ) -> [String] {
+        destinationRelativePaths.filter { rel in
+            !sourceRelativePaths.contains(rel)
+                && !ExcludeFilter.isExcluded(relativePath: rel, patterns: exclude)
+        }
+    }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Entry.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Entry.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The kind of filesystem object an ``Entry`` refers to.
+public enum EntryKind: Sendable, Equatable {
+    case file
+    case directory
+    case symlink
+}
+
+/// A single source/destination pair discovered while walking the source tree,
+/// together with the source-side metadata needed to make a copy decision.
+///
+/// `Entry` is a pure value type: it holds no open file handles and performs no
+/// I/O, so it is safe to pass across actor boundaries.
+public struct Entry: Sendable, Equatable {
+    /// Path of this entry relative to the sync root, using `/` separators.
+    /// Doubles as the human-readable description shown in progress output.
+    public var relativePath: String
+
+    /// Absolute location of the entry under the source root.
+    public var source: URL
+
+    /// Absolute location the entry should occupy under the destination root.
+    public var destination: URL
+
+    /// Whether the entry is a file, directory, or symlink.
+    public var kind: EntryKind
+
+    /// Size of the source entry in bytes. Zero for directories.
+    public var size: Int64
+
+    /// Modification time of the source entry, if known.
+    public var modificationDate: Date?
+
+    public init(
+        relativePath: String,
+        source: URL,
+        destination: URL,
+        kind: EntryKind,
+        size: Int64,
+        modificationDate: Date?
+    ) {
+        self.relativePath = relativePath
+        self.source = source
+        self.destination = destination
+        self.kind = kind
+        self.size = size
+        self.modificationDate = modificationDate
+    }
+
+    public var isFile: Bool { kind == .file }
+    public var isDirectory: Bool { kind == .directory }
+    public var isSymlink: Bool { kind == .symlink }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/ExcludeFilter.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/ExcludeFilter.swift
@@ -1,0 +1,59 @@
+/// Decides whether a relative path is excluded from a sync by a set of glob
+/// patterns. Pure and total — no I/O — so the matching rules can be exhaustively
+/// unit-tested.
+///
+/// Matching rules (deliberately small and predictable):
+/// - A pattern is a glob where `*` matches any run of characters (including
+///   `/`) and `?` matches exactly one character. Everything else is literal.
+/// - A pattern matches an entry when it matches the entry's **full relative
+///   path** (e.g. `docs/intro.md`) *or* the entry's **base name** (the last
+///   `/`-separated component, e.g. `intro.md`).
+/// - When an excluded entry is a directory, the caller prunes its whole subtree.
+///
+/// Examples: `*.tmp` excludes any path ending in `.tmp`; `build` excludes any
+/// file or directory named `build`; `docs/*` excludes the direct children of a
+/// top-level `docs` directory.
+public enum ExcludeFilter {
+    /// True when `relativePath` matches any of `patterns`. Empty `patterns`
+    /// excludes nothing.
+    public static func isExcluded(relativePath: String, patterns: [String]) -> Bool {
+        guard !patterns.isEmpty else { return false }
+        let base = String(relativePath.split(separator: "/").last ?? Substring(relativePath))
+        for pattern in patterns where !pattern.isEmpty {
+            if matches(pattern: pattern, name: relativePath) || matches(pattern: pattern, name: base) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Classic linear wildcard match with backtracking. `*` matches any
+    /// sequence (including empty), `?` matches any single character.
+    static func matches(pattern: String, name: String) -> Bool {
+        let p = Array(pattern)
+        let s = Array(name)
+        var pi = 0
+        var si = 0
+        var starIndex = -1
+        var matchIndex = 0
+
+        while si < s.count {
+            if pi < p.count, p[pi] == "?" || p[pi] == s[si] {
+                pi += 1
+                si += 1
+            } else if pi < p.count, p[pi] == "*" {
+                starIndex = pi
+                matchIndex = si
+                pi += 1
+            } else if starIndex != -1 {
+                pi = starIndex + 1
+                matchIndex += 1
+                si = matchIndex
+            } else {
+                return false
+            }
+        }
+        while pi < p.count, p[pi] == "*" { pi += 1 }
+        return pi == p.count
+    }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/FSOps.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/FSOps.swift
@@ -1,0 +1,228 @@
+import Foundation
+
+/// A minimal stat of a filesystem entry: just the two facts the copy decision
+/// depends on. Pure value type so the decision function can be tested without
+/// touching the filesystem.
+public struct FileStat: Equatable, Sendable {
+    /// Size in bytes.
+    public var size: Int64
+    /// Modification time, if the platform/filesystem reports one.
+    public var modificationDate: Date?
+
+    public init(size: Int64, modificationDate: Date?) {
+        self.size = size
+        self.modificationDate = modificationDate
+    }
+}
+
+/// Why a file was selected for copying.
+public enum CopyReason: Equatable, Sendable {
+    case destinationMissing
+    case sizeDiffers
+    case sourceNewer
+}
+
+/// The result of the copy decision: either copy (with the reason) or skip.
+public enum CopyDecision: Equatable, Sendable {
+    case copy(CopyReason)
+    case skip
+}
+
+/// Filesystem operations: the copy decision plus the byte-copy and
+/// metadata-preservation primitives that act on it.
+///
+/// `FSOps` owns the platform-touching surface of the tool, but keeps that
+/// surface tiny and routed through `FileManager` so it builds unchanged on
+/// macOS, Linux, and Windows.
+public enum FSOps {
+    /// **The single most important function in the tool.** Decides whether
+    /// `source` must be copied over `destination`. Pure and total — it performs
+    /// no I/O — so it can be exhaustively unit-tested. A bug here would mean
+    /// silent data divergence, so the decision matrix is tested case by case.
+    ///
+    /// Rules, evaluated in order (mirroring rusync's semantics):
+    /// 1. destination missing             → `.copy(.destinationMissing)`
+    /// 2. sizes differ                    → `.copy(.sizeDiffers)`
+    /// 3. source strictly newer than dest → `.copy(.sourceNewer)`
+    /// 4. otherwise                       → `.skip`
+    ///
+    /// The modification-time comparison requires both timestamps to be present
+    /// and uses strict greater-than. Equal timestamps, or an unknown timestamp
+    /// on either side once sizes already match, therefore resolve to `.skip` —
+    /// the tool never claims "newer" unless it can prove it.
+    public static func decideCopy(source: FileStat, destination: FileStat?) -> CopyDecision {
+        guard let destination else {
+            return .copy(.destinationMissing)
+        }
+        if source.size != destination.size {
+            return .copy(.sizeDiffers)
+        }
+        if let s = source.modificationDate, let d = destination.modificationDate, s > d {
+            return .copy(.sourceNewer)
+        }
+        return .skip
+    }
+
+    /// Reads size + modification date for `url`. Returns `nil` when the path does
+    /// not exist (the common "destination missing" case); throws
+    /// ``SyncError/metadataFailed(path:reason:)`` on any other failure.
+    public static func stat(at url: URL) throws -> FileStat? {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: url.path) else {
+            return nil
+        }
+        do {
+            let attrs = try fm.attributesOfItem(atPath: url.path)
+            let size = (attrs[.size] as? NSNumber)?.int64Value ?? 0
+            let mdate = attrs[.modificationDate] as? Date
+            return FileStat(size: size, modificationDate: mdate)
+        } catch {
+            throw SyncError.metadataFailed(path: url.path, reason: String(describing: error))
+        }
+    }
+
+    private static let copyChunkSize = 256 * 1024
+
+    /// Copies the *bytes* of `source` to `destination` without ever truncating
+    /// the destination in place: the data is streamed to a temporary file in the
+    /// destination's own directory, flushed to disk, then moved over the target.
+    ///
+    /// On Windows we deliberately avoid `FileManager.replaceItemAt` (not
+    /// implemented there — it traps), so any existing destination is removed
+    /// immediately before the same-directory rename. That replacement window is
+    /// tiny but not perfectly atomic; it is documented rather than hidden.
+    ///
+    /// - Parameter onBytesCopied: called with the size of each chunk as it is
+    ///   written, so a progress reporter can follow along off the decision path.
+    /// - Returns: the total number of bytes copied.
+    @discardableResult
+    public static func copyFileContents(
+        from source: URL,
+        to destination: URL,
+        onBytesCopied: ((Int) -> Void)? = nil
+    ) throws -> Int64 {
+        let fm = FileManager.default
+        let destDir = destination.deletingLastPathComponent()
+        let tmp = destDir.appendingPathComponent(
+            ".swiftsync.tmp.\(ProcessInfo.processInfo.processIdentifier).\(UUID().uuidString)"
+        )
+
+        let input: FileHandle
+        do {
+            input = try FileHandle(forReadingFrom: source)
+        } catch {
+            throw SyncError.readFailed(path: source.path, reason: String(describing: error))
+        }
+
+        guard fm.createFile(atPath: tmp.path, contents: nil) else {
+            try? input.close()
+            throw SyncError.writeFailed(path: tmp.path, reason: "could not create temporary file")
+        }
+
+        var total: Int64 = 0
+        do {
+            let output = try FileHandle(forWritingTo: tmp)
+            do {
+                while let chunk = try input.read(upToCount: copyChunkSize), !chunk.isEmpty {
+                    try output.write(contentsOf: chunk)
+                    total += Int64(chunk.count)
+                    onBytesCopied?(chunk.count)
+                }
+                // Best-effort flush to stable storage before the rename. Some
+                // platforms may not honor this; the temp+rename still protects
+                // the destination from a half-written state.
+                try? output.synchronize()
+                try output.close()
+            } catch {
+                try? output.close()
+                throw error
+            }
+            try input.close()
+        } catch {
+            try? input.close()
+            try? fm.removeItem(at: tmp)
+            throw SyncError.copyFailed(entry: source.lastPathComponent, reason: String(describing: error))
+        }
+
+        do {
+            if fm.fileExists(atPath: destination.path) {
+                try fm.removeItem(at: destination)
+            }
+            try fm.moveItem(at: tmp, to: destination)
+        } catch {
+            try? fm.removeItem(at: tmp)
+            throw SyncError.writeFailed(path: destination.path, reason: String(describing: error))
+        }
+        return total
+    }
+
+    /// Copies `source`'s modification date onto `destination`.
+    ///
+    /// Precision is whatever `FileManager` reports on the platform: at least
+    /// second-level everywhere, sub-second where the filesystem supports it. We
+    /// stay on `FileManager` rather than dropping to `utimensat`/`SetFileTime`
+    /// because the decision function only relies on strict ordering, for which
+    /// this precision is sufficient.
+    public static func preserveModificationDate(from source: URL, to destination: URL) throws {
+        let fm = FileManager.default
+        let attrs: [FileAttributeKey: Any]
+        do {
+            attrs = try fm.attributesOfItem(atPath: source.path)
+        } catch {
+            throw SyncError.metadataFailed(path: source.path, reason: String(describing: error))
+        }
+        guard let mdate = attrs[.modificationDate] as? Date else { return }
+        do {
+            try fm.setAttributes([.modificationDate: mdate], ofItemAtPath: destination.path)
+        } catch {
+            throw SyncError.writeFailed(
+                path: destination.path,
+                reason: "could not set modification date: \(error)"
+            )
+        }
+    }
+
+    /// Copies `source`'s POSIX permission bits onto `destination`.
+    ///
+    /// This is largely a no-op on Windows, where POSIX modes are not
+    /// meaningfully represented; callers make `--no-perms` the implicit default
+    /// there. On macOS and Linux it preserves the mode bits.
+    public static func preservePermissions(from source: URL, to destination: URL) throws {
+        let fm = FileManager.default
+        let attrs: [FileAttributeKey: Any]
+        do {
+            attrs = try fm.attributesOfItem(atPath: source.path)
+        } catch {
+            throw SyncError.metadataFailed(path: source.path, reason: String(describing: error))
+        }
+        guard let perms = attrs[.posixPermissions] as? NSNumber else { return }
+        do {
+            try fm.setAttributes([.posixPermissions: perms], ofItemAtPath: destination.path)
+        } catch {
+            throw SyncError.writeFailed(
+                path: destination.path,
+                reason: "could not set permissions: \(error)"
+            )
+        }
+    }
+
+    /// Full file copy: atomic byte copy, then modification-time preservation,
+    /// then optional permission preservation. The order matters — metadata is
+    /// applied to the destination only after its bytes are safely in place.
+    ///
+    /// - Returns: the number of bytes copied.
+    @discardableResult
+    public static func copyFile(
+        from source: URL,
+        to destination: URL,
+        preservePermissions preservePerms: Bool = true,
+        onBytesCopied: ((Int) -> Void)? = nil
+    ) throws -> Int64 {
+        let copied = try copyFileContents(from: source, to: destination, onBytesCopied: onBytesCopied)
+        try preserveModificationDate(from: source, to: destination)
+        if preservePerms {
+            try preservePermissions(from: source, to: destination)
+        }
+        return copied
+    }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Formatters.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Formatters.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Formats a byte count using binary (IEC) units: `B`, `KiB`, `MiB`, …
+///
+/// Replaces the upstream `humansize` dependency. Rounding is done manually so
+/// the output is deterministic and locale-independent — important for the
+/// golden-output tests and for parity across macOS, Linux, and Windows.
+public enum HumanSize {
+    private static let units = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"]
+
+    public static func string(_ bytes: Int64) -> String {
+        if bytes < 1024 {
+            return "\(bytes) B"
+        }
+        var value = Double(bytes)
+        var unitIndex = 0
+        while value >= 1024, unitIndex < units.count - 1 {
+            value /= 1024
+            unitIndex += 1
+        }
+        // Round to one decimal place without String(format:) to dodge any
+        // locale-dependent decimal separators.
+        let scaled = Int64((value * 10).rounded())
+        let whole = scaled / 10
+        let frac = abs(scaled % 10)
+        return "\(whole).\(frac) \(units[unitIndex])"
+    }
+}
+
+/// Formats a whole number of seconds as a zero-padded `HH:MM:SS` clock.
+///
+/// Replaces the upstream `humantime` dependency for the live ETA. Hours are not
+/// capped, so very long transfers render like `200:00:02`. Negative inputs are
+/// clamped to zero.
+public enum HumanDuration {
+    public static func clock(_ seconds: Int) -> String {
+        let s = max(0, seconds)
+        let hours = s / 3600
+        let minutes = (s / 60) % 60
+        let secs = s % 60
+        return "\(pad2(hours)):\(pad2(minutes)):\(pad2(secs))"
+    }
+
+    private static func pad2(_ n: Int) -> String {
+        n < 10 ? "0\(n)" : "\(n)"
+    }
+}
+
+/// Computes the path of `target` relative to `base`, using `/` separators.
+///
+/// Replaces the upstream `pathdiff` dependency. Path splitting accepts both `/`
+/// and `\` so it behaves identically given POSIX or Windows-style inputs; the
+/// result always uses `/`. Returns `"."` when the two paths are equal.
+public enum RelativePath {
+    public static func string(from base: String, to target: String) -> String {
+        let baseParts = components(base)
+        let targetParts = components(target)
+
+        var i = 0
+        while i < baseParts.count, i < targetParts.count, baseParts[i] == targetParts[i] {
+            i += 1
+        }
+
+        let ups = baseParts.count - i
+        var result = Array(repeating: "..", count: ups)
+        result.append(contentsOf: targetParts[i...])
+        return result.isEmpty ? "." : result.joined(separator: "/")
+    }
+
+    public static func string(from base: URL, to target: URL) -> String {
+        string(from: base.path, to: target.path)
+    }
+
+    private static func components(_ path: String) -> [String] {
+        path
+            .split(whereSeparator: { $0 == "/" || $0 == "\\" })
+            .map(String.init)
+            .filter { $0 != "." }
+    }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Progress.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Progress.swift
@@ -1,0 +1,60 @@
+/// A live snapshot of transfer progress, suitable for rendering a one-line
+/// status with an ETA. All byte counts are in bytes.
+public struct ProgressInfo: Sendable, Equatable {
+    /// Name (relative path) of the file currently being transferred.
+    public var currentFile: String
+    /// Bytes transferred so far for the current file.
+    public var fileDone: Int
+    /// Total size of the current file in bytes.
+    public var fileSize: Int
+    /// Bytes transferred across all files since the run started.
+    public var totalDone: Int
+    /// Estimated total size of the whole transfer in bytes.
+    public var totalSize: Int
+    /// 1-based index of the current file among all files to transfer.
+    public var index: Int
+    /// Total number of files to transfer.
+    public var numFiles: Int
+    /// Estimated time remaining, in whole seconds.
+    public var eta: Int
+
+    public init(
+        currentFile: String = "",
+        fileDone: Int = 0,
+        fileSize: Int = 0,
+        totalDone: Int = 0,
+        totalSize: Int = 0,
+        index: Int = 0,
+        numFiles: Int = 0,
+        eta: Int = 0
+    ) {
+        self.currentFile = currentFile
+        self.fileDone = fileDone
+        self.fileSize = fileSize
+        self.totalDone = totalDone
+        self.totalSize = totalSize
+        self.index = index
+        self.numFiles = numFiles
+        self.eta = eta
+    }
+}
+
+/// Messages emitted by the sync pipeline toward the progress reporter.
+///
+/// In the worker model these flow over an `AsyncStream` from the syncer to the
+/// progress reporter, keeping all rendering off the hot copy path.
+public enum ProgressMessage: Sendable, Equatable {
+    /// A transfer from `source` to `destination` has begun.
+    case started(source: String, destination: String)
+    /// The work to be done is known: `numFiles` files totalling `totalBytes`
+    /// bytes will actually be copied. Drives the percent and ETA denominators.
+    case planned(numFiles: Int, totalBytes: Int)
+    /// A new file named `name` (of `size` bytes) is being transferred.
+    case fileStarted(name: String, size: Int)
+    /// `bytes` more bytes were copied for the current file.
+    case progressed(bytes: Int)
+    /// The current file finished transferring.
+    case fileDone
+    /// The whole transfer is complete.
+    case done
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/SyncError.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/SyncError.swift
@@ -1,0 +1,36 @@
+/// Every way a sync can fail.
+///
+/// Mirrors the single `anyhow`-style error surface of the upstream tool: one
+/// error type with a case per failure mode, each carrying enough context to
+/// render a single useful line.
+public enum SyncError: Error, Equatable, Sendable, CustomStringConvertible {
+    case sourceDoesNotExist(path: String)
+    case notADirectory(path: String)
+    case readFailed(path: String, reason: String)
+    case writeFailed(path: String, reason: String)
+    case createDirectoryFailed(path: String, reason: String)
+    case metadataFailed(path: String, reason: String)
+    case copyFailed(entry: String, reason: String)
+    case errorListWriteFailed(path: String, reason: String)
+
+    public var description: String {
+        switch self {
+        case let .sourceDoesNotExist(path):
+            return "source does not exist: \(path)"
+        case let .notADirectory(path):
+            return "not a directory: \(path)"
+        case let .readFailed(path, reason):
+            return "could not read '\(path)': \(reason)"
+        case let .writeFailed(path, reason):
+            return "could not write '\(path)': \(reason)"
+        case let .createDirectoryFailed(path, reason):
+            return "could not create directory '\(path)': \(reason)"
+        case let .metadataFailed(path, reason):
+            return "could not read metadata for '\(path)': \(reason)"
+        case let .copyFailed(entry, reason):
+            return "could not copy '\(entry)': \(reason)"
+        case let .errorListWriteFailed(path, reason):
+            return "could not write error list '\(path)': \(reason)"
+        }
+    }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/SyncStats.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/SyncStats.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Running tally of what a sync did. Pure value type so it is trivial to assert
+/// on in tests and to hand to a progress reporter.
+public struct SyncStats: Sendable, Equatable {
+    /// Number of regular-file entries the syncer considered.
+    public var filesConsidered: Int = 0
+    /// Files actually copied (destination missing / size differed / source newer).
+    public var filesCopied: Int = 0
+    /// Files left untouched because the destination was already current.
+    public var filesUpToDate: Int = 0
+    /// Directories created because they did not already exist at the destination.
+    public var directoriesCreated: Int = 0
+    /// Symlinks created at the destination where none existed.
+    public var symlinksCreated: Int = 0
+    /// Symlinks replaced at the destination because they already existed.
+    public var symlinksUpdated: Int = 0
+    /// Total bytes copied across all files.
+    public var bytesCopied: Int64 = 0
+    /// Entries removed from the destination because they had no source
+    /// counterpart (only ever non-zero when `--delete` is in effect).
+    public var deleted: Int = 0
+    /// Number of entries that failed (one count per failed entry).
+    public var errors: Int = 0
+
+    public init() {}
+}
+
+/// A single per-entry failure. The whole run never aborts on one of these; they
+/// are collected and surfaced (and optionally written to an `--err-list` file).
+public struct SyncFailure: Sendable, Equatable {
+    /// Relative path of the entry that failed (the same name shown in progress).
+    public var entry: String
+    /// Human-readable reason.
+    public var message: String
+
+    public init(entry: String, message: String) {
+        self.entry = entry
+        self.message = message
+    }
+}
+
+/// The complete result of a sync: the tally plus every entry that errored.
+public struct SyncSummary: Sendable, Equatable {
+    public var stats: SyncStats
+    public var failures: [SyncFailure]
+
+    public init(stats: SyncStats = SyncStats(), failures: [SyncFailure] = []) {
+        self.stats = stats
+        self.failures = failures
+    }
+
+    /// True when no entry errored.
+    public var succeeded: Bool { failures.isEmpty }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Syncer.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/Syncer.swift
@@ -1,0 +1,246 @@
+import Foundation
+
+/// Drives a one-shot recursive sync from a source directory into a destination
+/// directory: it walks the tree, creates directories on the fly, applies the
+/// copy decision to each file, preserves symlinks, and tallies a ``SyncSummary``.
+///
+/// Per the data-safety posture, a failure on one entry **never aborts the run** —
+/// it is recorded in the summary and the walk continues. Nothing is deleted
+/// unless `Options.delete` is set, and even then only destination entries with
+/// no source counterpart (never anything under the source) are removed.
+///
+/// `Syncer` is an actor so that, in a later phase, a progress reporter can run
+/// concurrently while this consumes entries. For now the work is synchronous
+/// within the actor and an optional ``onProgress`` sink emits raw
+/// ``ProgressMessage`` values for that future reporter to consume.
+public actor Syncer {
+    /// Tunable behavior for a sync.
+    public struct Options: Sendable {
+        /// Preserve POSIX permission bits on copied files. Callers make this
+        /// `false` on Windows, where the bits are not meaningful.
+        public var preservePermissions: Bool
+
+        /// Glob patterns whose matching entries are skipped during the walk
+        /// (and, when `delete` is on, protected from deletion). Empty by default.
+        public var exclude: [String]
+
+        /// Remove destination entries that have no source counterpart after the
+        /// copy pass. Off by default — `swiftsync` never deletes unless asked.
+        public var delete: Bool
+
+        /// Follow symlinks and copy what they point to (rsync's `-L`) instead of
+        /// recreating the link. Off by default — links are preserved as links.
+        public var copyLinks: Bool
+
+        public init(
+            preservePermissions: Bool = true,
+            exclude: [String] = [],
+            delete: Bool = false,
+            copyLinks: Bool = false
+        ) {
+            self.preservePermissions = preservePermissions
+            self.exclude = exclude
+            self.delete = delete
+            self.copyLinks = copyLinks
+        }
+    }
+
+    private let source: URL
+    private let destination: URL
+    private let options: Options
+    private let onProgress: (@Sendable (ProgressMessage) -> Void)?
+
+    public init(
+        source: URL,
+        destination: URL,
+        options: Options = Options(),
+        onProgress: (@Sendable (ProgressMessage) -> Void)? = nil
+    ) {
+        self.source = source
+        self.destination = destination
+        self.options = options
+        self.onProgress = onProgress
+    }
+
+    /// Performs the sync and returns the tally plus any per-entry failures.
+    ///
+    /// - Throws: only for *fatal* conditions that prevent the run from starting
+    ///   (source missing/not a directory, destination root not creatable).
+    ///   Per-entry problems are captured in the returned summary, not thrown.
+    public func run() throws -> SyncSummary {
+        let fm = FileManager.default
+
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: source.path, isDirectory: &isDir) else {
+            throw SyncError.sourceDoesNotExist(path: source.path)
+        }
+        guard isDir.boolValue else {
+            throw SyncError.notADirectory(path: source.path)
+        }
+        do {
+            try fm.createDirectory(at: destination, withIntermediateDirectories: true)
+        } catch {
+            throw SyncError.createDirectoryFailed(path: destination.path, reason: String(describing: error))
+        }
+
+        let entries = try TreeWalker.walk(
+            source: source, destination: destination,
+            exclude: options.exclude, copyLinks: options.copyLinks)
+
+        var summary = SyncSummary()
+        onProgress?(.started(source: source.path, destination: destination.path))
+
+        // Plan pass: when a progress reporter is attached, pre-compute how many
+        // files (and bytes) will actually be copied so it has accurate percent
+        // and ETA denominators. Skipped entirely when there is no reporter (the
+        // scriptable, piped path) to avoid the extra stats.
+        if onProgress != nil {
+            var plannedFiles = 0
+            var plannedBytes = 0
+            for entry in entries where entry.kind == .file {
+                let destinationStat = try? FSOps.stat(at: entry.destination)
+                let sourceStat = FileStat(size: entry.size, modificationDate: entry.modificationDate)
+                if case .copy = FSOps.decideCopy(source: sourceStat, destination: destinationStat) {
+                    plannedFiles += 1
+                    plannedBytes += Int(entry.size)
+                }
+            }
+            onProgress?(.planned(numFiles: plannedFiles, totalBytes: plannedBytes))
+        }
+
+        for entry in entries {
+            do {
+                switch entry.kind {
+                case .directory:
+                    try syncDirectory(entry, fm: fm, stats: &summary.stats)
+                case .file:
+                    try syncFile(entry, fm: fm, stats: &summary.stats)
+                case .symlink:
+                    try syncSymlink(entry, fm: fm, stats: &summary.stats)
+                }
+            } catch {
+                // Surface, never abort.
+                summary.stats.errors += 1
+                let message = (error as? SyncError)?.description ?? String(describing: error)
+                summary.failures.append(SyncFailure(entry: entry.relativePath, message: message))
+            }
+        }
+
+        // Delete pass: only when asked. Remove destination entries that have no
+        // source counterpart (and are not excluded). Like the copy pass, a
+        // per-entry failure here is captured and never aborts the run.
+        if options.delete {
+            deletePass(sourceEntries: entries, fm: fm, summary: &summary)
+        }
+
+        onProgress?(.done)
+        return summary
+    }
+
+    /// Removes destination entries with no source counterpart. The set of source
+    /// paths comes from the (already exclude-pruned) walk, so excluded paths are
+    /// implicitly absent and therefore protected by ``DeletionPlan`` as well.
+    private func deletePass(sourceEntries: [Entry], fm: FileManager, summary: inout SyncSummary) {
+        let destinationEntries: [Entry]
+        do {
+            // Enumerate the destination tree. Excludes are applied here too so an
+            // excluded path at the destination is never even considered.
+            destinationEntries = try TreeWalker.walk(
+                source: destination, destination: destination, exclude: options.exclude)
+        } catch {
+            summary.stats.errors += 1
+            let message = (error as? SyncError)?.description ?? String(describing: error)
+            summary.failures.append(SyncFailure(entry: ".", message: "delete walk failed: \(message)"))
+            return
+        }
+
+        let sourcePaths = Set(sourceEntries.map(\.relativePath))
+        let toDelete = DeletionPlan.entriesToDelete(
+            sourceRelativePaths: sourcePaths,
+            destinationRelativePaths: destinationEntries.map(\.relativePath),
+            exclude: options.exclude
+        )
+
+        // Remove deepest paths first so a directory's children are gone (and
+        // individually counted) before the directory itself is removed.
+        let ordered = toDelete.sorted {
+            $0.split(separator: "/").count > $1.split(separator: "/").count
+        }
+        for rel in ordered {
+            let url = destination.appendingPathComponent(rel)
+            // May already be gone if a parent was removed first; that cannot
+            // happen with deepest-first ordering, but guard defensively.
+            guard (try? fm.attributesOfItem(atPath: url.path)) != nil else { continue }
+            do {
+                try fm.removeItem(at: url)
+                summary.stats.deleted += 1
+            } catch {
+                summary.stats.errors += 1
+                summary.failures.append(SyncFailure(entry: rel, message: "could not delete: \(error)"))
+            }
+        }
+    }
+
+    private func syncDirectory(_ entry: Entry, fm: FileManager, stats: inout SyncStats) throws {
+        if fm.fileExists(atPath: entry.destination.path) { return }
+        do {
+            try fm.createDirectory(at: entry.destination, withIntermediateDirectories: true)
+            stats.directoriesCreated += 1
+        } catch {
+            throw SyncError.createDirectoryFailed(path: entry.destination.path, reason: String(describing: error))
+        }
+    }
+
+    private func syncFile(_ entry: Entry, fm: FileManager, stats: inout SyncStats) throws {
+        stats.filesConsidered += 1
+
+        let sourceStat = FileStat(size: entry.size, modificationDate: entry.modificationDate)
+        let destinationStat = try FSOps.stat(at: entry.destination)
+
+        switch FSOps.decideCopy(source: sourceStat, destination: destinationStat) {
+        case .skip:
+            stats.filesUpToDate += 1
+
+        case .copy:
+            onProgress?(.fileStarted(name: entry.relativePath, size: Int(entry.size)))
+            let byteSink: ((Int) -> Void)? = onProgress.map { sink in
+                { bytes in sink(.progressed(bytes: bytes)) }
+            }
+            let copied = try FSOps.copyFile(
+                from: entry.source,
+                to: entry.destination,
+                preservePermissions: options.preservePermissions,
+                onBytesCopied: byteSink
+            )
+            stats.filesCopied += 1
+            stats.bytesCopied += copied
+            onProgress?(.fileDone)
+        }
+    }
+
+    private func syncSymlink(_ entry: Entry, fm: FileManager, stats: inout SyncStats) throws {
+        let target: String
+        do {
+            target = try fm.destinationOfSymbolicLink(atPath: entry.source.path)
+        } catch {
+            throw SyncError.readFailed(path: entry.source.path, reason: String(describing: error))
+        }
+
+        // lstat-style existence check so an existing (even broken) symlink at the
+        // destination is detected and replaced rather than duplicated.
+        let destinationExists = (try? fm.attributesOfItem(atPath: entry.destination.path)) != nil
+        if destinationExists {
+            try? fm.removeItem(at: entry.destination)
+        }
+        do {
+            try fm.createSymbolicLink(atPath: entry.destination.path, withDestinationPath: target)
+        } catch {
+            throw SyncError.writeFailed(path: entry.destination.path, reason: String(describing: error))
+        }
+        if destinationExists {
+            stats.symlinksUpdated += 1
+        } else {
+            stats.symlinksCreated += 1
+        }
+    }
+}

--- a/source/ios-swift-swiftsync/Sources/SwiftSyncCore/TreeWalker.swift
+++ b/source/ios-swift-swiftsync/Sources/SwiftSyncCore/TreeWalker.swift
@@ -1,0 +1,210 @@
+import Foundation
+
+/// Walks a source directory tree and produces an ``Entry`` for every item under
+/// it (files, directories, and symlinks), pairing each with the destination
+/// path it should occupy.
+///
+/// The walk is **pre-order**: a directory entry always appears before the
+/// entries it contains, so a consumer can create each directory before copying
+/// anything into it. By default symlinks are reported as leaf
+/// ``EntryKind/symlink`` entries and are never followed, so the tree cannot
+/// loop. When `copyLinks` is set (rsync's `-L`/`--copy-links`), a symlink is
+/// instead *followed* and reported as the file or directory it points to; a
+/// cycle guard prevents runaway recursion, and dangling links are skipped.
+/// Children are visited in sorted name order for deterministic output
+/// (important for the fixture tests).
+public enum TreeWalker {
+    /// Produces entries for everything under `source`, with destination paths
+    /// rooted at `destination`. The roots themselves are not emitted — only
+    /// their contents, mirroring `swiftsync SRC DEST` placing SRC's contents
+    /// directly under DEST.
+    ///
+    /// Entries matching any `exclude` glob are pruned: an excluded file or
+    /// symlink is skipped, and an excluded directory is skipped *along with its
+    /// entire subtree* (we never descend into it).
+    ///
+    /// When `copyLinks` is true, symlinks are resolved to their referent: a link
+    /// to a file is emitted as that file (with the target's size/mtime and the
+    /// target as the copy source), and a link to a directory is descended into.
+    /// Dangling links are skipped.
+    ///
+    /// - Throws: ``SyncError/sourceDoesNotExist(path:)`` or
+    ///   ``SyncError/notADirectory(path:)`` if the source root is unusable.
+    public static func walk(
+        source: URL,
+        destination: URL,
+        exclude: [String] = [],
+        copyLinks: Bool = false
+    ) throws -> [Entry] {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: source.path, isDirectory: &isDir) else {
+            throw SyncError.sourceDoesNotExist(path: source.path)
+        }
+        guard isDir.boolValue else {
+            throw SyncError.notADirectory(path: source.path)
+        }
+
+        var entries: [Entry] = []
+        // Canonical directory paths already descended into, so a followed
+        // symlink that points back to an ancestor cannot loop forever. Only
+        // consulted when `copyLinks` is on (a plain tree has no cycles).
+        var visited: Set<String> = copyLinks ? [source.standardizedFileURL.path] : []
+        try walkDirectory(
+            relativePrefix: "",
+            source: source,
+            destination: destination,
+            exclude: exclude,
+            copyLinks: copyLinks,
+            visited: &visited,
+            into: &entries,
+            fm: fm
+        )
+        return entries
+    }
+
+    private static func walkDirectory(
+        relativePrefix: String,
+        source: URL,
+        destination: URL,
+        exclude: [String],
+        copyLinks: Bool,
+        visited: inout Set<String>,
+        into entries: inout [Entry],
+        fm: FileManager
+    ) throws {
+        let names: [String]
+        do {
+            names = try fm.contentsOfDirectory(atPath: source.path).sorted()
+        } catch {
+            throw SyncError.readFailed(path: source.path, reason: String(describing: error))
+        }
+
+        for name in names {
+            let childSource = source.appendingPathComponent(name)
+            let childDestination = destination.appendingPathComponent(name)
+            let relativePath = relativePrefix.isEmpty ? name : "\(relativePrefix)/\(name)"
+
+            // Prune excluded entries (and, for directories, their whole subtree).
+            if ExcludeFilter.isExcluded(relativePath: relativePath, patterns: exclude) {
+                continue
+            }
+
+            // `attributesOfItem` uses lstat semantics on every platform, so it
+            // does not follow symlinks — a symlink reports as a symlink.
+            let attrs = try? fm.attributesOfItem(atPath: childSource.path)
+            let type = attrs?[.type] as? FileAttributeType
+            let mdate = attrs?[.modificationDate] as? Date
+
+            // --copy-links: resolve a symlink to its referent and treat it as
+            // that file/directory instead of recreating the link.
+            if copyLinks, type == .some(.typeSymbolicLink) {
+                guard
+                    let targetURL = resolvedTarget(of: childSource, fm: fm),
+                    let targetAttrs = try? fm.attributesOfItem(atPath: targetURL.path)
+                else {
+                    // Dangling or unresolvable link: skip (matches rsync's
+                    // warn-and-skip for a symlink with no referent under -L).
+                    continue
+                }
+                let targetType = targetAttrs[.type] as? FileAttributeType
+                let targetMdate = targetAttrs[.modificationDate] as? Date
+
+                if targetType == .some(.typeDirectory) {
+                    entries.append(Entry(
+                        relativePath: relativePath,
+                        source: targetURL,
+                        destination: childDestination,
+                        kind: .directory,
+                        size: 0,
+                        modificationDate: targetMdate
+                    ))
+                    let canon = targetURL.standardizedFileURL.path
+                    if !visited.contains(canon) {
+                        visited.insert(canon)
+                        try walkDirectory(
+                            relativePrefix: relativePath,
+                            source: targetURL,
+                            destination: childDestination,
+                            exclude: exclude,
+                            copyLinks: copyLinks,
+                            visited: &visited,
+                            into: &entries,
+                            fm: fm
+                        )
+                    }
+                } else {
+                    let size = (targetAttrs[.size] as? NSNumber)?.int64Value ?? 0
+                    entries.append(Entry(
+                        relativePath: relativePath,
+                        source: targetURL,
+                        destination: childDestination,
+                        kind: .file,
+                        size: size,
+                        modificationDate: targetMdate
+                    ))
+                }
+                continue
+            }
+
+            switch type {
+            case .some(.typeDirectory):
+                entries.append(Entry(
+                    relativePath: relativePath,
+                    source: childSource,
+                    destination: childDestination,
+                    kind: .directory,
+                    size: 0,
+                    modificationDate: mdate
+                ))
+                try walkDirectory(
+                    relativePrefix: relativePath,
+                    source: childSource,
+                    destination: childDestination,
+                    exclude: exclude,
+                    copyLinks: copyLinks,
+                    visited: &visited,
+                    into: &entries,
+                    fm: fm
+                )
+
+            case .some(.typeSymbolicLink):
+                entries.append(Entry(
+                    relativePath: relativePath,
+                    source: childSource,
+                    destination: childDestination,
+                    kind: .symlink,
+                    size: 0,
+                    modificationDate: mdate
+                ))
+
+            default:
+                // Regular file, or anything we could not stat (emitted as a file
+                // so the copy attempt surfaces the real error instead of being
+                // silently dropped).
+                let size = (attrs?[.size] as? NSNumber)?.int64Value ?? 0
+                entries.append(Entry(
+                    relativePath: relativePath,
+                    source: childSource,
+                    destination: childDestination,
+                    kind: .file,
+                    size: size,
+                    modificationDate: mdate
+                ))
+            }
+        }
+    }
+
+    /// Resolves one level of symbolic link to an absolute URL. Relative targets
+    /// are resolved against the link's own directory. Returns `nil` when the
+    /// path is not a symlink we can read; the resulting URL may still point at a
+    /// non-existent file (a dangling link), which the caller detects by failing
+    /// to stat it.
+    private static func resolvedTarget(of link: URL, fm: FileManager) -> URL? {
+        guard let dest = try? fm.destinationOfSymbolicLink(atPath: link.path) else { return nil }
+        if (dest as NSString).isAbsolutePath {
+            return URL(fileURLWithPath: dest)
+        }
+        return link.deletingLastPathComponent().appendingPathComponent(dest).standardizedFileURL
+    }
+}

--- a/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/Package.swift
+++ b/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:6.0
+//
+// examples/adaptivecards-swiftsync-demo/Package.swift
+//
+// Runtime symbol-check example for the vendored SwiftSyncCore kit. Flavor A
+// ("store / round-trip"): sync the canonical adaptivecards.io "Hello World"
+// sample card from a temp source directory into a temp destination directory
+// via the public `Syncer` API, read it back, and assert byte-equal.
+//
+// Path-deps the vendored kit at ../.. . SwiftSyncCore is pure Foundation with no
+// external package dependencies, so there is no substrate to mirror here.
+
+import PackageDescription
+
+let package = Package(
+    name: "AdaptiveCardsSwiftSyncDemo",
+    platforms: [
+        .macOS(.v12),
+    ],
+    products: [
+        .executable(name: "AdaptiveCardsDemo", targets: ["AdaptiveCardsDemo"]),
+    ],
+    dependencies: [
+        // Path-dep on the vendored kit.
+        .package(name: "SwiftSyncCore", path: "../.."),
+    ],
+    targets: [
+        .executableTarget(
+            name: "AdaptiveCardsDemo",
+            dependencies: [
+                .product(name: "SwiftSyncCore", package: "SwiftSyncCore"),
+            ]
+        ),
+    ]
+)

--- a/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/README.md
+++ b/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/README.md
@@ -1,0 +1,46 @@
+# adaptivecards-swiftsync-demo
+
+A self-contained SwiftPM package that proves the vendored **`SwiftSyncCore`**
+snapshot actually links and runs after vendoring — not just that it compiles.
+
+It is **flavor A ("store / round-trip")**: it takes the canonical
+adaptivecards.io "Hello World" card, writes it into a temp **source** directory,
+drives the vendored `Syncer` to recursively copy that directory into a temp
+**destination** directory, reads the card back from the destination, and asserts
+the bytes are byte-for-byte identical. It then uses `FSOps` to confirm a second
+pass would be a no-op (the pure copy decision is `.skip`).
+
+On success it prints exactly:
+
+```
+PASS adaptivecards-swiftsync-roundtrip
+```
+
+`smoke.ps1` (Windows) and `smoke.sh` (POSIX) build the demo, run it, and exit
+non-zero unless that PASS line is observed. The proxy-only CI gate runs
+`smoke.ps1` on Windows MSVC.
+
+## Run
+
+```pwsh
+./smoke.ps1
+```
+
+```sh
+./smoke.sh
+```
+
+## Symbols exercised
+
+The demo calls these distinct public `SwiftSyncCore` symbols (well over the
+required three):
+
+- `Syncer(source:destination:options:)` and `Syncer.run()` — drive the recursive
+  directory sync.
+- `Syncer.Options(preservePermissions:exclude:delete:copyLinks:)` — configure it.
+- `SyncSummary` and `SyncStats.filesCopied` / `SyncStats.bytesCopied` — assert the
+  tally (exactly one file copied) and report the transferred size.
+- `FSOps.stat(at:)` and `FSOps.decideCopy(source:destination:)` (returning
+  `CopyDecision.skip`) — prove a re-sync is a no-op once the destination is
+  current.
+- `HumanSize.string(_:)` — format the copied byte count for the log line.

--- a/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/Sources/AdaptiveCardsDemo/SampleCard.swift
+++ b/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/Sources/AdaptiveCardsDemo/SampleCard.swift
@@ -1,0 +1,26 @@
+// SampleCard.swift
+// Canonical "Hello World" Adaptive Card payload as published on
+// https://adaptivecards.io/samples/ . Embedded verbatim so the
+// runtime symbol-check exercises a real AdaptiveCard JSON shape, not
+// a synthesized one.
+
+import Foundation
+
+enum SampleCard {
+    /// The minimal "Hello World" Adaptive Card from adaptivecards.io,
+    /// schema 1.5. Used as both the synced input and the read-back
+    /// expected bytes in the demo round-trip.
+    static let helloWorldJSON: String = """
+    {
+        "type": "AdaptiveCard",
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.5",
+        "body": [
+            {
+                "type": "TextBlock",
+                "text": "Hello, World!"
+            }
+        ]
+    }
+    """
+}

--- a/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/Sources/AdaptiveCardsDemo/main.swift
+++ b/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/Sources/AdaptiveCardsDemo/main.swift
@@ -1,0 +1,122 @@
+// main.swift
+//
+// Runtime symbol-check demo for the vendored SwiftSyncCore kit — flavor A
+// ("store / round-trip").
+//
+// It takes the canonical adaptivecards.io "Hello World" card, writes it into a
+// temp SOURCE directory, drives the vendored `Syncer` to recursively copy that
+// directory into a temp DESTINATION directory, reads the card back from the
+// destination, and asserts the bytes are byte-for-byte identical. It then uses
+// `FSOps` to prove a second pass would be a no-op (the decision is `.skip`).
+//
+// On success it prints exactly:  PASS adaptivecards-swiftsync-roundtrip
+// On any failure it writes a FAIL line to stderr and exits non-zero, so the
+// smoke scripts and CI gate on the PASS line.
+//
+// Symbols exercised (>= 3 distinct public SwiftSyncCore symbols):
+//   1. Syncer(source:destination:options:) + Syncer.run()
+//   2. Syncer.Options(preservePermissions:exclude:delete:copyLinks:)
+//   3. SyncSummary / SyncStats.filesCopied
+//   4. FSOps.stat(at:) + FSOps.decideCopy(source:destination:) (+ CopyDecision)
+//   5. HumanSize.string(_:)
+
+import Foundation
+import SwiftSyncCore
+
+func fail(_ message: String) -> Never {
+    FileHandle.standardError.write(Data("FAIL adaptivecards-swiftsync-roundtrip: \(message)\n".utf8))
+    exit(1)
+}
+
+// 1. Lay down the canonical card in a temp SOURCE directory.
+let fm = FileManager.default
+let work = fm.temporaryDirectory.appendingPathComponent("acm-swiftsync-\(UUID().uuidString)")
+let srcDir = work.appendingPathComponent("src")
+let dstDir = work.appendingPathComponent("dst")
+defer { try? fm.removeItem(at: work) }
+
+do {
+    try fm.createDirectory(at: srcDir, withIntermediateDirectories: true)
+} catch {
+    fail("could not create source dir: \(error)")
+}
+
+let cardName = "hello-world.card.json"
+let originalBytes = Data(SampleCard.helloWorldJSON.utf8)
+let srcCard = srcDir.appendingPathComponent(cardName)
+do {
+    try originalBytes.write(to: srcCard)
+} catch {
+    fail("could not write source card: \(error)")
+}
+
+// 2. Drive the vendored Syncer to copy SRC -> DST. POSIX permission bits are not
+//    meaningful on Windows, so preservation is off here.
+let options = Syncer.Options(
+    preservePermissions: false,
+    exclude: [],
+    delete: false,
+    copyLinks: false
+)
+let syncer = Syncer(source: srcDir, destination: dstDir, options: options)
+
+let summary: SyncSummary
+do {
+    summary = try await syncer.run()
+} catch {
+    fail("sync threw: \(error)")
+}
+
+guard summary.succeeded else {
+    fail("sync reported \(summary.stats.errors) error(s): \(summary.failures)")
+}
+guard summary.stats.filesCopied == 1 else {
+    fail("expected exactly 1 file copied, got \(summary.stats.filesCopied)")
+}
+
+// 3. Read the card back from the DESTINATION and assert byte-identical.
+let dstCard = dstDir.appendingPathComponent(cardName)
+let readBack: Data
+do {
+    readBack = try Data(contentsOf: dstCard)
+} catch {
+    fail("could not read destination card: \(error)")
+}
+guard readBack == originalBytes else {
+    fail("round-trip byte mismatch (src \(originalBytes.count) B vs dst \(readBack.count) B)")
+}
+
+// 4. Use FSOps to prove a re-sync would be a no-op: stat both sides and confirm
+//    the pure copy decision is `.skip` (destination already current).
+let srcStat: FileStat?
+let dstStat: FileStat?
+do {
+    srcStat = try FSOps.stat(at: srcCard)
+    dstStat = try FSOps.stat(at: dstCard)
+} catch {
+    fail("FSOps.stat threw: \(error)")
+}
+guard let s = srcStat, let d = dstStat else {
+    fail("FSOps.stat returned nil for a file that exists")
+}
+guard FSOps.decideCopy(source: s, destination: d) == .skip else {
+    fail("expected a re-sync to be a no-op (.skip), but the decision was to copy")
+}
+
+// 5. Sanity-check the parsed card shape (Foundation JSONSerialization) and
+//    format the transferred size with the kit's HumanSize formatter.
+let parsedType: String
+do {
+    let obj = try JSONSerialization.jsonObject(with: readBack) as? [String: Any]
+    let body = obj?["body"] as? [[String: Any]]
+    parsedType = (body?.first?["type"] as? String) ?? "<none>"
+} catch {
+    fail("destination card is not valid JSON: \(error)")
+}
+guard parsedType == "TextBlock" else {
+    fail("expected body[0].type == TextBlock, got \(parsedType)")
+}
+
+let human = HumanSize.string(summary.stats.bytesCopied)
+print("synced 1 card (\(human)); body[0].type = \(parsedType); re-sync decision = skip")
+print("PASS adaptivecards-swiftsync-roundtrip")

--- a/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/smoke.ps1
+++ b/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/smoke.ps1
@@ -1,0 +1,55 @@
+#!/usr/bin/env pwsh
+# Runtime symbol-check smoke for the vendored SwiftSyncCore kit (flavor A —
+# store / round-trip). Builds the demo, runs it, and gates on the PASS line.
+# Exits non-zero on any failure so CI fails unless the PASS line prints.
+#
+# SwiftSyncCore is pure Foundation, so there are no zlib (-ZlibInc/-ZlibLib)
+# parameters here, unlike the NIO-backed bridges.
+
+param(
+    # Optional unique SwiftPM scratch path, used locally to avoid build-DB lock
+    # collisions when several bridge agents build in parallel. CI omits it.
+    [string]$ScratchPath = ""
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$PASS = 'PASS adaptivecards-swiftsync-roundtrip'
+
+# Prime the Swift toolchain env from the registry (Windows DevBox); harmless in
+# CI and elsewhere, where these scopes return nothing.
+$machinePath = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+$userPath = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+if ($machinePath) { $env:Path = "$machinePath;$userPath" }
+$sdk = [System.Environment]::GetEnvironmentVariable('SDKROOT', 'User')
+if ($sdk) { $env:SDKROOT = $sdk }
+
+Push-Location $PSScriptRoot
+try {
+    $buildArgs = @('build', '-c', 'debug')
+    $runArgs = @('run', '-c', 'debug', 'AdaptiveCardsDemo')
+    if ($ScratchPath) {
+        $buildArgs += @('--scratch-path', $ScratchPath)
+        $runArgs += @('--scratch-path', $ScratchPath)
+    }
+
+    Write-Host "== build demo =="
+    & swift @buildArgs
+    if ($LASTEXITCODE -ne 0) { Write-Host "FAIL: swift build failed" -ForegroundColor Red; exit 1 }
+
+    Write-Host "== run demo =="
+    $output = & swift @runArgs 2>&1
+    $output | ForEach-Object { Write-Host $_ }
+    if ($LASTEXITCODE -ne 0) { Write-Host "FAIL: demo exited $LASTEXITCODE" -ForegroundColor Red; exit 1 }
+
+    if (($output -join "`n") -match [regex]::Escape($PASS)) {
+        Write-Host "smoke OK: '$PASS' observed" -ForegroundColor Green
+        exit 0
+    }
+    Write-Host "FAIL: '$PASS' not found in demo output" -ForegroundColor Red
+    exit 1
+}
+finally {
+    Pop-Location
+}

--- a/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/smoke.sh
+++ b/source/ios-swift-swiftsync/examples/adaptivecards-swiftsync-demo/smoke.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Runtime symbol-check smoke for the vendored SwiftSyncCore kit (flavor A —
+# store / round-trip). Builds the demo, runs it, and gates on the PASS line.
+# Exits non-zero on any failure.
+#
+# SwiftSyncCore is pure Foundation, so there are no zlib flags here.
+
+set -euo pipefail
+
+PASS='PASS adaptivecards-swiftsync-roundtrip'
+
+cd "$(dirname "$0")"
+
+echo "== build demo =="
+swift build -c debug
+
+echo "== run demo =="
+output="$(swift run -c debug AdaptiveCardsDemo 2>&1)"
+echo "$output"
+
+if echo "$output" | grep -qF "$PASS"; then
+    echo "smoke OK: '$PASS' observed"
+    exit 0
+fi
+
+echo "FAIL: '$PASS' not found in demo output" >&2
+exit 1


### PR DESCRIPTION
Proxy-only feature branch. Not for upstream.

Adds `source/ios-swift-swiftsync/` — a vendored snapshot of the SwiftSyncCore engine (a general-purpose, pure-Foundation, rsync-style recursive directory-sync engine) as an experimental, parallel Swift surface alongside the production Adaptive Cards mobile SDK.

- Vendored as of 2026-06-17; inherits the repo-root MIT license (no nested LICENSE, no GPL per-file headers).
- Pure Foundation: zero external package dependencies, so the committed `Package.swift` has no SSH-alias URLs; no Apple-only imports.
- Mandatory runtime symbol-check demo at `examples/adaptivecards-swiftsync-demo/` (flavor A - store/round-trip): syncs the canonical adaptivecards.io `Hello World` card from a temp source dir into a temp destination dir via the public `Syncer` API, reads it back, asserts byte-equality, and confirms a re-sync is a no-op. Exercises >=3 distinct public symbols and prints `PASS adaptivecards-swiftsync-roundtrip`.
- CI: `.github/workflows/swift-swiftsync-bridge-gate.yml` (Windows MSVC, Swift 6.3.1): manual NTFS-safe checkout, `swift build -c debug` of the kit, then the demo smoke gated on the PASS line. No continue-on-error. No zlib (pure Foundation).
- No changes to existing ObjC / Java / C++ shipping code.