### PR TITLE
feat(swift-swiftoauth-bridge): initial proxy drop

### DIFF
--- a/.github/workflows/swift-swiftoauth-bridge-gate.yml
+++ b/.github/workflows/swift-swiftoauth-bridge-gate.yml
@@ -1,0 +1,81 @@
+# proxy-only — do NOT cherry-pick this workflow to any clean/* branch
+# or to any PR targeting microsoft/main. Lives only on:
+#   hggz/AdaptiveCards-Mobile  : proxy/feat-swift-swiftoauth-bridge, proxy/integration
+#   hggzm/Teams-AdaptiveCards-Mobile : proxy/integration (after merge)
+name: swift-swiftoauth-bridge gate
+
+on:
+  push:
+    branches:
+      - 'proxy/feat-swift-swiftoauth-bridge'
+      - 'proxy/integration'
+    paths:
+      - 'source/ios-swift-swiftoauth/**'
+      - '.github/workflows/swift-swiftoauth-bridge-gate.yml'
+  pull_request:
+    branches: [ 'proxy/integration' ]
+    paths:
+      - 'source/ios-swift-swiftoauth/**'
+      - '.github/workflows/swift-swiftoauth-bridge-gate.yml'
+
+jobs:
+  windows-msvc:
+    name: Windows MSVC / Swift 6.3.1
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      # The proxy/integration tree carries a tracked file with a colon
+      # in its name ('t-Path C:\Users\hugogonzalez\teams_branch_diffs.txt'),
+      # which is invalid on NTFS. `actions/checkout@v4` runs `git checkout`
+      # which rejects that path with exit 128 regardless of sparse-checkout
+      # settings. Workaround: clone manually with `core.protectNTFS=false`
+      # so git on Windows ignores the NTFS-safety check on that one path;
+      # everything we care about (source/ios-swift-swiftoauth/ + this
+      # workflow) is safe.
+      - name: Manual checkout with protectNTFS=false
+        env:
+          REPO: ${{ github.repository }}
+          REF: ${{ github.sha }}
+        run: |
+          git config --global core.protectNTFS false
+          git init .
+          git remote add origin "https://github.com/$env:REPO.git"
+          git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin $env:REF
+          git checkout --progress --force $env:REF
+          git rev-parse HEAD
+
+      - name: Install Swift 6.3.1
+        uses: compnerd/gha-setup-swift@main
+        with:
+          # compnerd/gha-setup-swift wants the release-branch name in
+          # swift-version (NOT just the version number) and the
+          # corresponding RELEASE tag in swift-build. This matches the
+          # pattern used by hggz/swiftci and hggz/giteax CI.
+          swift-version: "swift-6.3.1-release"
+          swift-build:   "6.3.1-RELEASE"
+
+      - name: swift --version
+        run: swift --version
+
+      # ----------------------------------------------------------------
+      # Step 1 (compile floor): the vendored kit must build clean.
+      # No zlib: the loopback server uses Hummingbird's HTTP/1 runtime
+      # (swift-nio + swift-nio-extras), not nio-ssl/compression.
+      # ----------------------------------------------------------------
+      - name: swift build -c debug (kit)
+        working-directory: source/ios-swift-swiftoauth
+        run: |
+          swift build -c debug
+          if ($LASTEXITCODE -ne 0) { throw "kit build failed" }
+
+      # ----------------------------------------------------------------
+      # Step 2 (link + execute): the symbol-check demo must build, run,
+      # and emit `PASS adaptivecards-swiftoauth-http`.
+      # ----------------------------------------------------------------
+      - name: smoke (build + run + assert PASS)
+        working-directory: source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo
+        run: |
+          ./smoke.ps1
+          if ($LASTEXITCODE -ne 0) { throw "smoke failed" }

--- a/docs/PROXY_PR_LOG.md
+++ b/docs/PROXY_PR_LOG.md
@@ -163,3 +163,13 @@ Toggle test: initial=54 elements -> expanded=56 -> collapsed=54 (round-trip conf
 **Fix:**
 - iOS: Set `ACRView.accessibilityLabel` from card speak property via `GetSpeak()` with full null-safety guards
 - Android: Set `contentDescription` from speak; set `accessibilityLiveRegion = POLITE`
+
+## Swift-on-Windows Bridge — swiftoauth OAuth 2.0 Playground
+
+| # | Issue | Proxy Branch | Clean Branch | Upstream PR | Fix |
+|---|-------|-------------|-------------|------------|-----|
+| 41 | Vendor the swiftoauth Swift-on-Windows OAuth 2.0 playground as an experimental proxy-only parallel surface alongside the production ObjC/Java/C++ AdaptiveCards stack. | proxy/feat-swift-swiftoauth-bridge | — | pending | source/ios-swift-swiftoauth/: vendored snapshot of swiftoauth (Swift 6 OAuth 2.0 authorization-code + PKCE playground with a 127.0.0.1 loopback callback server, over the hggz Phase-F NIO substrate) + runtime symbol-check demo at examples/adaptivecards-swiftoauth-demo/ binding the loopback server and round-tripping the canonical adaptivecards.io Hello-World card fact through a CSRF-validated loopback HTTP exchange. CI: .github/workflows/swift-swiftoauth-bridge-gate.yml (Windows MSVC build + smoke). No edits to existing ObjC/Java/C++ shipping code. |
+
+**Scope:** Proxy-only, experimental. Vendored on 2026-06-17; inherits repo-root MIT. No nested LICENSE, no GPL per-file headers, no SSH URLs in committed Package.swift. Substrate pinned to public hggz forks (hummingbird 3e892143, swift-nio 7c9c6861, swift-nio-extras 076c9b49) at the same revisions used by hggz/swiftci and hggz/giteax. No zlib needed (loopback server uses Hummingbird's HTTP/1 runtime, not nio-ssl/compression).
+
+**Symbol-check coverage:** The mandatory ADDENDUM-v2 §13 demo (Flavor B / transport) exercises OAuthState (generate/value/matches), PKCE (generate/codeVerifier/codeChallenge/isValidVerifier/challenge), CallbackServerConfig (init/redirectURI), CallbackServer (init/run), CallbackServer.RunResult (outcome/boundPort/redirectURI), and CallbackOutcome against the canonical adaptivecards.io Hello-World JSON. The demo binds 127.0.0.1, validates a constant-time CSRF state, asserts the captured code equals the derived body[0].type fact, and prints PASS adaptivecards-swiftoauth-http on success.

--- a/source/ios-swift-swiftoauth/.gitattributes
+++ b/source/ios-swift-swiftoauth/.gitattributes
@@ -1,0 +1,11 @@
+# Force LF on all text in this vendored subfolder so the Swift-on-Windows
+# sources behave identically on macOS, Linux, and Windows MSVC CI. Stray
+# CR bytes break the NIO substrate and Linux toolchains.
+* text=auto eol=lf
+*.swift text eol=lf
+*.json  text eol=lf
+*.md    text eol=lf
+*.sh    text eol=lf
+*.ps1   text eol=lf
+*.yml   text eol=lf
+*.yaml  text eol=lf

--- a/source/ios-swift-swiftoauth/.gitignore
+++ b/source/ios-swift-swiftoauth/.gitignore
@@ -1,0 +1,7 @@
+# Build artifacts — never committed.
+.build/
+.swiftpm/
+Package.resolved
+vcpkg_installed/
+.DS_Store
+*.log

--- a/source/ios-swift-swiftoauth/Package.swift
+++ b/source/ios-swift-swiftoauth/Package.swift
@@ -1,0 +1,82 @@
+// swift-tools-version:6.0
+// swiftoauth vendored snapshot for the Adaptive Cards Mobile proxy
+// integration drop.
+//
+// Vendored from hggz/swiftoauth as of 2026-06-17; this snapshot inherits
+// the repo-root MIT license. No nested LICENSE file. No private commit
+// SHAs are referenced.
+//
+// Diffs from the upstream Package.swift:
+//
+//   1. The `swiftoauth` executable target and its CLI sources
+//      (ArgumentParser command front-end + AsyncHTTPClientTransport)
+//      have been dropped — the symbol-check drop only needs libraries
+//      the demo can `import`.
+//   2. The `swift-argument-parser`, `async-http-client`, and
+//      `swift-nio-ssl` dependencies have been removed; they were only
+//      wired into the dropped CLI executable. The loopback callback
+//      server (SwiftOAuthServer) runs on Hummingbird's HTTP/1 runtime
+//      alone, which pulls swift-nio + swift-nio-extras but NOT
+//      nio-ssl/compression — so this drop needs no zlib and no TLS
+//      stack on any platform.
+//   3. The NIO substrate forks remain pinned to the same public hggz
+//      revisions used by hggz/swiftci and hggz/giteax; those forks
+//      carry the Windows-specific Swift 6.x shims upstream master does
+//      not yet have.
+
+import PackageDescription
+
+let package = Package(
+    name: "swiftoauth",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+        .tvOS(.v17),
+        .watchOS(.v10),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(name: "SwiftOAuthCore", targets: ["SwiftOAuthCore"]),
+        .library(name: "SwiftOAuthServer", targets: ["SwiftOAuthServer"]),
+    ],
+    dependencies: [
+        // Cross-platform SHA-256 for PKCE S256 (NOT CryptoKit — Apple-only).
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+
+        // Loopback callback server substrate. Public hggz Windows-supported
+        // forks, pinned to the Hummingbird-compatible SHAs used by the sibling
+        // hggz repos (swiftci / giteax).
+        .package(url: "https://github.com/hggz/hummingbird.git",
+                 revision: "3e8921437eb791e06662d9f8cbfcd55f18c4759a"),
+        .package(url: "https://github.com/hggz/swift-nio.git",
+                 revision: "7c9c6861c968f8902c0610ab4ba2e23311f5092c"),
+        .package(url: "https://github.com/hggz/swift-nio-extras.git",
+                 revision: "076c9b493c6fe365ba42663fc16c4239d17dfb92"),
+    ],
+    targets: [
+        .target(
+            name: "SwiftOAuthCore",
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
+            ]
+        ),
+        .target(
+            name: "SwiftOAuthServer",
+            dependencies: [
+                "SwiftOAuthCore",
+                .product(name: "Hummingbird", package: "hummingbird"),
+            ]
+        ),
+        .testTarget(
+            name: "SwiftOAuthCoreTests",
+            dependencies: ["SwiftOAuthCore"]
+        ),
+        .testTarget(
+            name: "SwiftOAuthServerTests",
+            dependencies: [
+                "SwiftOAuthServer",
+                "SwiftOAuthCore",
+            ]
+        ),
+    ]
+)

--- a/source/ios-swift-swiftoauth/README.md
+++ b/source/ios-swift-swiftoauth/README.md
@@ -1,0 +1,71 @@
+# ios-swift-swiftoauth
+
+An **experimental, proxy-only** Swift surface vendored alongside the
+production Adaptive Cards Mobile iOS (ObjC/C++), Android (Java), and
+shared (C++) stacks. It touches none of them.
+
+This is a vendored snapshot of **swiftoauth** — a general-purpose,
+Swift-native OAuth 2.0 playground that drives real authorization-code +
+PKCE flows and captures the provider callback on a local `127.0.0.1`
+loopback server. It builds and runs on **Windows MSVC** (Swift 6.3.1) on
+top of the hggz Swift-on-Windows substrate.
+
+**Vendored:** 2026-06-17. This subfolder **inherits the repo-root MIT
+license** — there is no nested `LICENSE` file and no per-file license
+headers.
+
+## What's here
+
+| Library | Purpose |
+|---|---|
+| `SwiftOAuthCore` | PKCE (RFC 7636) S256, CSRF `state` (RFC 6749 §10.12), token / identity value types, the GitHub / Discord / Mastodon providers, token store, redaction helpers. Depends on `swift-crypto` only. |
+| `SwiftOAuthServer` | The loopback OAuth callback server (RFC 8252): binds `127.0.0.1`, serves one `GET /callback`, validates `state` exactly, and shuts down after one callback. Built on Hummingbird's HTTP/1 runtime. |
+
+The upstream kit also ships a `swiftoauth` CLI executable
+(ArgumentParser + AsyncHTTPClient). That front-end is **not** part of
+this drop — the bridge vendors only the libraries the symbol-check demo
+can `import`.
+
+## Substrate pins
+
+All network dependencies are public `hggz/*` Windows-supported forks,
+pinned to the same revisions used by the sibling hggz repos (swiftci,
+giteax):
+
+| Package | Revision |
+|---|---|
+| `hggz/hummingbird` | `3e892143` |
+| `hggz/swift-nio` | `7c9c6861` |
+| `hggz/swift-nio-extras` | `076c9b49` |
+| `apple/swift-crypto` | `from: 3.0.0` (public) |
+
+The committed `Package.swift` contains **no `git@…` SSH URLs** — every
+dependency resolves from a public HTTPS remote, so CI can fetch it.
+
+This drop needs **no zlib**: the loopback server uses Hummingbird's
+HTTP/1 runtime, which pulls `swift-nio` + `swift-nio-extras` but not
+`nio-ssl`/compression.
+
+## Symbols exercised
+
+The mandatory runtime symbol-check demo lives at
+[`examples/adaptivecards-swiftoauth-demo/`](examples/adaptivecards-swiftoauth-demo/).
+It binds `SwiftOAuthServer.CallbackServer` on `127.0.0.1`, parses the
+canonical adaptivecards.io "Hello World" card with Foundation
+`JSONDecoder`, and round-trips the derived `body[0].type` fact through a
+real loopback HTTP exchange validated by the kit's CSRF `state`. It
+exercises `OAuthState`, `PKCE`, `CallbackServerConfig`, `CallbackServer`,
+`CallbackServer.RunResult`, and `CallbackOutcome`, then prints
+`PASS adaptivecards-swiftoauth-http`. See that folder's README for the
+full symbol list.
+
+## Building on Windows
+
+```pwsh
+swift build -c debug
+cd examples/adaptivecards-swiftoauth-demo
+./smoke.ps1
+```
+
+CI: [`.github/workflows/swift-swiftoauth-bridge-gate.yml`](../../.github/workflows/swift-swiftoauth-bridge-gate.yml)
+(Windows MSVC, build + symbol-check smoke).

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Base64URL.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Base64URL.swift
@@ -1,0 +1,30 @@
+// Source: RFC 4648 §5 — The Base 16, Base 32, and Base 64 Data Encodings
+//         (base64url alphabet, used unpadded by RFC 7636 PKCE).
+import Foundation
+
+/// base64url (RFC 4648 §5) encoding **without** trailing `=` padding, as
+/// required by RFC 7636 for the PKCE `code_challenge` and used throughout
+/// swiftoauth for high-entropy URL-safe tokens.
+public enum Base64URL {
+    /// Encode raw bytes as unpadded base64url.
+    public static func encode(_ bytes: some Sequence<UInt8>) -> String {
+        var s = Data(bytes).base64EncodedString()
+        s = s.replacingOccurrences(of: "+", with: "-")
+        s = s.replacingOccurrences(of: "/", with: "_")
+        s = s.replacingOccurrences(of: "=", with: "")
+        return s
+    }
+
+    /// Decode an (optionally padded) base64url string back to bytes.
+    /// Returns `nil` if the input is not valid base64url.
+    public static func decode(_ string: String) -> Data? {
+        var s = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = s.count % 4
+        if remainder != 0 {
+            s += String(repeating: "=", count: 4 - remainder)
+        }
+        return Data(base64Encoded: s)
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/ConstantTime.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/ConstantTime.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Constant-time comparison helpers, used for CSRF `state` and token checks so
+/// that validation does not leak secret contents through timing.
+public enum ConstantTime {
+    /// Compare two strings in time independent of their *contents*.
+    ///
+    /// Differing lengths return `false` immediately (a value's length is not
+    /// itself the secret here); equal-length inputs are compared byte-by-byte
+    /// with no early-out.
+    public static func equals(_ a: String, _ b: String) -> Bool {
+        let lhs = Array(a.utf8)
+        let rhs = Array(b.utf8)
+        guard lhs.count == rhs.count else { return false }
+        var difference: UInt8 = 0
+        for index in 0..<lhs.count {
+            difference |= lhs[index] ^ rhs[index]
+        }
+        return difference == 0
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/DynamicClientRegistration.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/DynamicClientRegistration.swift
@@ -1,0 +1,33 @@
+// Source: docs.joinmastodon.org/methods/apps — dynamic app (client) registration.
+//         (Conceptually OAuth 2.0 Dynamic Client Registration, RFC 7591, but the
+//         concrete fields here are Mastodon's own published `POST /api/v1/apps`.)
+import Foundation
+
+/// Client credentials obtained from a provider's dynamic app-registration step.
+public struct ClientCredentials: Codable, Sendable, Equatable {
+    public let clientID: String
+    public let clientSecret: String?
+
+    public init(clientID: String, clientSecret: String?) {
+        self.clientID = clientID
+        self.clientSecret = clientSecret
+    }
+}
+
+/// A provider that registers an app at runtime to obtain client credentials
+/// (e.g. Mastodon, where each instance issues its own `client_id`/`client_secret`).
+///
+/// This is still a pure value transformation: build the registration request,
+/// parse the response. The transport executes it, exactly like the token flow.
+public protocol DynamicClientRegistration: OAuthProvider {
+    /// Build the request that registers an app and yields client credentials.
+    func appRegistrationRequest(
+        clientName: String,
+        redirectURI: URL,
+        scopes: [String],
+        website: URL?
+    ) -> HTTPRequest
+
+    /// Parse the registration response into ``ClientCredentials``.
+    func parseAppRegistration(_ body: Data) throws -> ClientCredentials
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/FormURLEncoding.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/FormURLEncoding.swift
@@ -1,0 +1,22 @@
+// Source: RFC 6749 Appendix B / RFC 3986 §2.3 — token endpoints consume an
+//         `application/x-www-form-urlencoded` body with percent-encoded values.
+import Foundation
+
+/// `application/x-www-form-urlencoded` encoding for OAuth token requests.
+public enum FormURLEncoding {
+    /// Encode `fields` as a form body. Keys are sorted so output is
+    /// deterministic (which keeps fixtures and tests stable).
+    public static func encode(_ fields: [String: String]) -> String {
+        fields
+            .sorted { $0.key < $1.key }
+            .map { "\(escape($0.key))=\(escape($0.value))" }
+            .joined(separator: "&")
+    }
+
+    /// Percent-encode per RFC 3986: leave only the unreserved set unescaped.
+    private static func escape(_ string: String) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return string.addingPercentEncoding(withAllowedCharacters: allowed) ?? string
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/HTTPRequest.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/HTTPRequest.swift
@@ -1,0 +1,51 @@
+// Source: RFC 6749 §3.2 / §4.1 / RFC 6750 §2.1 — token-endpoint POST and the
+//         bearer-token identity GET, expressed here as a pure value.
+import Foundation
+
+/// A provider-built HTTP request, as a pure value with no networking attached.
+///
+/// Keeping requests as plain data lets the three providers be unit-tested with
+/// zero network access (assert on the request shape), and lets the CLI's
+/// transport layer (AsyncHTTPClient, added in a later phase) execute them.
+public struct HTTPRequest: Sendable, Equatable {
+    public enum Method: String, Sendable {
+        case GET
+        case POST
+        case DELETE
+    }
+
+    public var method: Method
+    public var url: URL
+    public var headers: [String: String]
+    public var body: Data?
+
+    public init(method: Method, url: URL, headers: [String: String] = [:], body: Data? = nil) {
+        self.method = method
+        self.url = url
+        self.headers = headers
+        self.body = body
+    }
+
+    /// Build a POST with an `application/x-www-form-urlencoded` body from form
+    /// `fields` (the content type OAuth token endpoints expect, RFC 6749 §4.1.3).
+    public static func formPOST(
+        url: URL,
+        fields: [String: String],
+        headers: [String: String] = [:]
+    ) -> HTTPRequest {
+        var merged = headers
+        merged["Content-Type"] = "application/x-www-form-urlencoded"
+        let encoded = FormURLEncoding.encode(fields)
+        return HTTPRequest(method: .POST, url: url, headers: merged, body: Data(encoded.utf8))
+    }
+
+    /// A redaction-safe one-line rendering for logs: sensitive header values
+    /// are masked and the body is never included.
+    public var redactedDescription: String {
+        let renderedHeaders = Redaction.redactHeaders(headers)
+            .map { "\($0.key): \($0.value)" }
+            .sorted()
+            .joined(separator: ", ")
+        return "\(method.rawValue) \(url.absoluteString) [\(renderedHeaders)]"
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Identity.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Identity.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// The minimal, non-secret identity swiftoauth reads back after login to prove
+/// a token works (`whoami`). Provider-specific identity payloads are normalized
+/// into these fields; `raw` may carry a few selected non-secret extras.
+public struct Identity: Codable, Sendable, Equatable {
+    public let providerID: String
+    /// The provider's stable account identifier.
+    public let id: String
+    /// Login / handle, if the provider exposes one.
+    public let username: String?
+    public let displayName: String?
+    public let raw: [String: String]?
+
+    public init(
+        providerID: String,
+        id: String,
+        username: String? = nil,
+        displayName: String? = nil,
+        raw: [String: String]? = nil
+    ) {
+        self.providerID = providerID
+        self.id = id
+        self.username = username
+        self.displayName = displayName
+        self.raw = raw
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthClient.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthClient.swift
@@ -1,0 +1,95 @@
+// Source: RFC 6749 §4.1.3 (authorization-code exchange), §6 (refresh),
+//         RFC 6750 §2.1 (bearer identity request).
+//
+// Orchestrates a provider + a transport: build the provider's request, send it,
+// check the status, and parse the body back into a value type. No secrets are
+// ever logged here; non-2xx bodies are redacted before being surfaced in errors.
+import Foundation
+
+/// Drives provider flows over an injected ``OAuthTransport``.
+public struct OAuthClient: Sendable {
+    public let transport: any OAuthTransport
+
+    public init(transport: any OAuthTransport) {
+        self.transport = transport
+    }
+
+    /// Exchange an authorization `code` for a ``TokenSet`` (RFC 6749 §4.1.3).
+    public func exchangeAuthorizationCode(
+        provider: any OAuthProvider,
+        code: String,
+        codeVerifier: String?,
+        redirectURI: URL
+    ) async throws -> TokenSet {
+        let request = provider.tokenRequest(code: code, codeVerifier: codeVerifier, redirectURI: redirectURI)
+        let response = try await transport.send(request)
+        try Self.requireSuccessForToken(response)
+        return try provider.parseToken(response.body)
+    }
+
+    /// Exchange a refresh token for a fresh ``TokenSet`` (RFC 6749 §6).
+    public func refresh(
+        provider: any OAuthProvider,
+        refreshToken: String
+    ) async throws -> TokenSet {
+        let request = provider.refreshRequest(refreshToken: refreshToken)
+        let response = try await transport.send(request)
+        try Self.requireSuccessForToken(response)
+        return try provider.parseToken(response.body)
+    }
+
+    /// Fetch the authenticated identity with a bearer token (RFC 6750 §2.1).
+    public func fetchIdentity(
+        provider: any OAuthProvider,
+        accessToken: String
+    ) async throws -> Identity {
+        let request = provider.identityRequest(accessToken: accessToken)
+        let response = try await transport.send(request)
+        guard response.isSuccess else {
+            throw Self.providerError(response)
+        }
+        return try provider.parseIdentity(response.body)
+    }
+
+    /// Revoke a token (RFC 7009, or the provider's own revocation scheme).
+    ///
+    /// Throws ``OAuthError/revocationUnavailable(_:)`` if the provider does not
+    /// support revocation or cannot build a revocation request from its current
+    /// configuration, and ``OAuthError/providerError(code:description:)`` if the
+    /// provider rejects the request.
+    public func revoke(
+        provider: any OAuthProvider,
+        token: String,
+        tokenTypeHint: TokenTypeHint = .accessToken
+    ) async throws {
+        guard let revocable = provider as? TokenRevocation else {
+            throw OAuthError.revocationUnavailable("provider '\(provider.id)' does not support token revocation")
+        }
+        guard let request = revocable.revokeRequest(token: token, tokenTypeHint: tokenTypeHint) else {
+            throw OAuthError.revocationUnavailable("provider '\(provider.id)' needs client credentials to revoke")
+        }
+        let response = try await transport.send(request)
+        guard response.isSuccess else {
+            throw Self.providerError(response)
+        }
+    }
+
+    // MARK: - Status handling
+
+    /// Token endpoints: a non-2xx is a hard failure. (Some providers, e.g.
+    /// GitHub, return 200 with an `{"error": …}` body instead — that case is
+    /// left to `parseToken`, which detects and throws it.)
+    private static func requireSuccessForToken(_ response: OAuthHTTPResponse) throws {
+        guard response.isSuccess else {
+            throw providerError(response)
+        }
+    }
+
+    /// Build a redacted provider error from a non-2xx response.
+    private static func providerError(_ response: OAuthHTTPResponse) -> OAuthError {
+        let raw = String(decoding: response.body, as: UTF8.self)
+        let safe = Redaction.redactTokenJSON(raw)
+        let trimmed = safe.count > 500 ? String(safe.prefix(500)) + "…" : safe
+        return .providerError(code: "http_\(response.status)", description: trimmed.isEmpty ? nil : trimmed)
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthError.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthError.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Errors surfaced by SwiftOAuthCore. Messages never include secret material.
+public enum OAuthError: Error, Equatable, Sendable {
+    case invalidVerifier
+    case stateMismatch
+    case missingAuthorizationCode
+    case malformedTokenResponse(String)
+    case malformedIdentityResponse(String)
+    case providerError(code: String, description: String?)
+    case unknownProvider(String)
+    case missingConfiguration(String)
+    case revocationUnavailable(String)
+}
+
+extension OAuthError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .invalidVerifier:
+            return "PKCE code_verifier is not RFC 7636-valid"
+        case .stateMismatch:
+            return "OAuth state mismatch (possible CSRF) — rejected"
+        case .missingAuthorizationCode:
+            return "authorization response carried no code"
+        case .malformedTokenResponse(let why):
+            return "malformed token response: \(why)"
+        case .malformedIdentityResponse(let why):
+            return "malformed identity response: \(why)"
+        case .providerError(let code, let desc):
+            return "provider error \(code)" + (desc.map { ": \($0)" } ?? "")
+        case .unknownProvider(let id):
+            return "unknown provider '\(id)'"
+        case .missingConfiguration(let why):
+            return "missing configuration: \(why)"
+        case .revocationUnavailable(let why):
+            return "token revocation unavailable: \(why)"
+        }
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthProvider.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthProvider.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// The OAuth client credentials and scopes a provider needs to drive a flow.
+///
+/// For a confidential client (e.g. a GitHub OAuth App) `clientSecret` is set;
+/// for a public client that relies on PKCE it may be `nil`.
+public struct OAuthClientConfig: Sendable, Equatable {
+    public let clientID: String
+    public let clientSecret: String?
+    public let scopes: [String]
+    /// Provider-specific base URL (used by per-instance providers like Mastodon).
+    public let instanceBaseURL: URL?
+
+    public init(
+        clientID: String,
+        clientSecret: String? = nil,
+        scopes: [String] = [],
+        instanceBaseURL: URL? = nil
+    ) {
+        self.clientID = clientID
+        self.clientSecret = clientSecret
+        self.scopes = scopes
+        self.instanceBaseURL = instanceBaseURL
+    }
+}
+
+/// The OAuth shape each supported platform documents, expressed as pure value
+/// transformations: build URLs/requests, parse response bodies. No networking
+/// lives here, so every provider is unit-testable against recorded fixtures
+/// with zero live calls.
+public protocol OAuthProvider: Sendable {
+    /// Stable provider id, e.g. `"github"`.
+    var id: String { get }
+
+    /// Whether this provider's flow uses PKCE (RFC 7636).
+    var usesPKCE: Bool { get }
+
+    /// The authorization-request URL (RFC 6749 §4.1.1) to open in the browser.
+    func authorizeURL(state: String, codeChallenge: String?, redirectURI: URL) -> URL
+
+    /// The token-exchange request (RFC 6749 §4.1.3) for an authorization `code`.
+    func tokenRequest(code: String, codeVerifier: String?, redirectURI: URL) -> HTTPRequest
+
+    /// The refresh-token request (RFC 6749 §6).
+    func refreshRequest(refreshToken: String) -> HTTPRequest
+
+    /// The identity request (RFC 6750 bearer usage) that proves the token works.
+    func identityRequest(accessToken: String) -> HTTPRequest
+
+    /// Parse a token-endpoint response body into a `TokenSet`.
+    func parseToken(_ body: Data) throws -> TokenSet
+
+    /// Parse an identity-endpoint response body into an `Identity`.
+    func parseIdentity(_ body: Data) throws -> Identity
+}
+
+/// Registry of the built-in providers.
+public enum Providers {
+    /// IDs of the providers swiftoauth currently implements.
+    public static let knownIDs = ["github", "discord", "mastodon"]
+
+    /// Construct a built-in provider by id, or throw `.unknownProvider`.
+    ///
+    /// Mastodon is per-instance, so it additionally requires
+    /// `config.instanceBaseURL`; a missing instance throws `.missingConfiguration`
+    /// rather than crashing.
+    public static func make(id: String, config: OAuthClientConfig) throws -> any OAuthProvider {
+        switch id {
+        case "github":
+            return GitHubProvider(config: config)
+        case "discord":
+            return DiscordProvider(config: config)
+        case "mastodon":
+            guard config.instanceBaseURL != nil else {
+                throw OAuthError.missingConfiguration(
+                    "mastodon requires an instance URL (set SWIFTOAUTH_MASTODON_INSTANCE, e.g. https://mastodon.social)"
+                )
+            }
+            return MastodonProvider(config: config)
+        default:
+            throw OAuthError.unknownProvider(id)
+        }
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthState.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthState.swift
@@ -1,0 +1,27 @@
+// Source: RFC 6749 §10.12 — Cross-Site Request Forgery (the `state` parameter).
+import Foundation
+
+/// The CSRF `state` parameter (RFC 6749 §10.12): a fresh, single-use,
+/// high-entropy value bound to one authorization request and validated for an
+/// exact match when the provider redirects back to the loopback callback.
+public struct OAuthState: Sendable, Equatable {
+    public let value: String
+
+    public init(value: String) {
+        self.value = value
+    }
+
+    /// Generate a fresh state from `byteCount` bytes of CSPRNG entropy.
+    /// The default of 32 bytes yields a 43-character base64url token
+    /// (256 bits of entropy).
+    public static func generate(byteCount: Int = 32) -> OAuthState {
+        precondition(byteCount >= 16, "state needs at least 128 bits of entropy")
+        return OAuthState(value: Base64URL.encode(RandomBytes.generate(count: byteCount)))
+    }
+
+    /// Exact, constant-time comparison against the `state` the provider
+    /// returned. Any mismatch must be rejected (CSRF defense).
+    public func matches(_ returned: String) -> Bool {
+        ConstantTime.equals(value, returned)
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthTransport.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/OAuthTransport.swift
@@ -1,0 +1,32 @@
+// Source: RFC 6749 §4.1.3/§6 (token endpoint) + RFC 6750 §2.1 (bearer identity).
+//
+// A minimal HTTP transport abstraction. Keeping this a protocol (not a concrete
+// networking client) lets the token-exchange / refresh / identity flows be
+// unit-tested with a fake transport against recorded provider responses — the
+// test suite never opens a socket to a real provider. The CLI supplies the
+// concrete async-http-client implementation.
+import Foundation
+
+/// A provider-agnostic HTTP response: just the parts the OAuth flows need.
+public struct OAuthHTTPResponse: Sendable, Equatable {
+    public let status: Int
+    public let headers: [String: String]
+    public let body: Data
+
+    public init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+
+    /// Whether the status is in the 2xx success range.
+    public var isSuccess: Bool { (200..<300).contains(status) }
+}
+
+/// Executes an ``HTTPRequest`` and returns the response.
+///
+/// Conformers MUST keep TLS verification on — swiftoauth has no insecure escape
+/// hatch. The protocol is intentionally tiny so a test fake is trivial.
+public protocol OAuthTransport: Sendable {
+    func send(_ request: HTTPRequest) async throws -> OAuthHTTPResponse
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/PKCE.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/PKCE.swift
@@ -1,0 +1,62 @@
+// Source: RFC 7636 — Proof Key for Code Exchange by OAuth Public Clients.
+//   §4.1 code_verifier, §4.2 code_challenge (S256), Appendix B test vector.
+import Foundation
+import Crypto
+
+/// PKCE (RFC 7636) parameters for the authorization-code flow.
+///
+/// Only the **S256** challenge method is supported. `plain` is deliberately
+/// omitted — S256 is the only method swiftoauth will ever send.
+public struct PKCE: Sendable, Equatable {
+    /// High-entropy `code_verifier` (RFC 7636 §4.1): 43–128 characters from
+    /// the unreserved set `A–Z a–z 0–9 - . _ ~`.
+    public let codeVerifier: String
+
+    /// `code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))`
+    /// (RFC 7636 §4.2), unpadded.
+    public let codeChallenge: String
+
+    /// Always `"S256"`.
+    public let method: String
+
+    /// Wrap an existing verifier, deriving its S256 challenge.
+    public init(codeVerifier: String) {
+        self.codeVerifier = codeVerifier
+        self.codeChallenge = PKCE.challenge(for: codeVerifier)
+        self.method = "S256"
+    }
+
+    /// Generate a fresh PKCE pair from a cryptographically random verifier.
+    ///
+    /// - Parameter verifierByteCount: entropy in bytes. The default of 32
+    ///   produces a 43-character base64url verifier — the RFC-recommended
+    ///   minimum. The accepted range maps exactly onto the 43–128 character
+    ///   verifier window RFC 7636 §4.1 allows.
+    public static func generate(verifierByteCount: Int = 32) -> PKCE {
+        precondition(
+            verifierByteCount >= 32 && verifierByteCount <= 96,
+            "verifierByteCount must map to a 43–128 char verifier (32…96 bytes)"
+        )
+        let verifier = Base64URL.encode(RandomBytes.generate(count: verifierByteCount))
+        return PKCE(codeVerifier: verifier)
+    }
+
+    /// Compute the S256 challenge for a verifier (RFC 7636 §4.2).
+    public static func challenge(for verifier: String) -> String {
+        let digest = SHA256.hash(data: Data(verifier.utf8))
+        return Base64URL.encode(digest)
+    }
+
+    /// The unreserved characters permitted in a `code_verifier`.
+    public static let unreservedCharacters = Set(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+    )
+
+    /// Whether a string is a syntactically valid `code_verifier`
+    /// (RFC 7636 §4.1: 43–128 chars, unreserved set only).
+    public static func isValidVerifier(_ verifier: String) -> Bool {
+        let length = verifier.count
+        guard length >= 43 && length <= 128 else { return false }
+        return verifier.allSatisfy { unreservedCharacters.contains($0) }
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Providers/DiscordProvider.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Providers/DiscordProvider.swift
@@ -1,0 +1,147 @@
+// Source: discord.com/developers/docs/topics/oauth2 — "OAuth2".
+//   authorize: https://discord.com/oauth2/authorize
+//   token:     https://discord.com/api/oauth2/token  (application/x-www-form-urlencoded)
+//   identity:  GET https://discord.com/api/users/@me
+//   revoke:    POST https://discord.com/api/oauth2/token/revoke   (RFC 7009)
+//   PKCE: Discord supports the S256 code challenge for the authorization-code grant.
+import Foundation
+
+/// Discord OAuth provider.
+///
+/// Discord implements the standard authorization-code grant and supports PKCE
+/// (S256), so `usesPKCE` is `true`. A confidential app also sends its
+/// `client_secret` in the token request; both are forwarded when present. All
+/// endpoints come from Discord's own developer documentation (cited above).
+public struct DiscordProvider: OAuthProvider, TokenRevocation {
+    public let id = "discord"
+    public let usesPKCE = true
+    public let config: OAuthClientConfig
+
+    public init(config: OAuthClientConfig) {
+        self.config = config
+    }
+
+    private let authorizeEndpoint = URL(string: "https://discord.com/oauth2/authorize")!
+    private let tokenEndpoint = URL(string: "https://discord.com/api/oauth2/token")!
+    private let identityEndpoint = URL(string: "https://discord.com/api/users/@me")!
+    private let revokeEndpoint = URL(string: "https://discord.com/api/oauth2/token/revoke")!
+
+    public func authorizeURL(state: String, codeChallenge: String?, redirectURI: URL) -> URL {
+        var components = URLComponents(url: authorizeEndpoint, resolvingAgainstBaseURL: false)!
+        var items = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: config.clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI.absoluteString),
+            URLQueryItem(name: "state", value: state),
+        ]
+        if !config.scopes.isEmpty {
+            // Discord uses space-delimited scopes (e.g. "identify email").
+            items.append(URLQueryItem(name: "scope", value: config.scopes.joined(separator: " ")))
+        }
+        if let codeChallenge {
+            items.append(URLQueryItem(name: "code_challenge", value: codeChallenge))
+            items.append(URLQueryItem(name: "code_challenge_method", value: "S256"))
+        }
+        components.queryItems = items
+        return components.url!
+    }
+
+    public func tokenRequest(code: String, codeVerifier: String?, redirectURI: URL) -> HTTPRequest {
+        var fields = [
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirectURI.absoluteString,
+            "client_id": config.clientID,
+        ]
+        if let secret = config.clientSecret { fields["client_secret"] = secret }
+        if let codeVerifier { fields["code_verifier"] = codeVerifier }
+        return HTTPRequest.formPOST(url: tokenEndpoint, fields: fields)
+    }
+
+    public func refreshRequest(refreshToken: String) -> HTTPRequest {
+        var fields = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": config.clientID,
+        ]
+        if let secret = config.clientSecret { fields["client_secret"] = secret }
+        return HTTPRequest.formPOST(url: tokenEndpoint, fields: fields)
+    }
+
+    public func identityRequest(accessToken: String) -> HTTPRequest {
+        HTTPRequest(
+            method: .GET,
+            url: identityEndpoint,
+            headers: [
+                "Authorization": "Bearer \(accessToken)",
+                "Accept": "application/json",
+            ]
+        )
+    }
+
+    // RFC 7009 revocation: form POST with the token, a type hint, and client
+    // authentication (Discord requires the client_id, and client_secret for a
+    // confidential app).
+    public func revokeRequest(token: String, tokenTypeHint: TokenTypeHint) -> HTTPRequest? {
+        var fields = [
+            "token": token,
+            "token_type_hint": tokenTypeHint.rawValue,
+            "client_id": config.clientID,
+        ]
+        if let secret = config.clientSecret { fields["client_secret"] = secret }
+        return HTTPRequest.formPOST(url: revokeEndpoint, fields: fields)
+    }
+
+    public func parseToken(_ body: Data) throws -> TokenSet {
+        let decoder = JSONDecoder()
+        if let failure = try? decoder.decode(DiscordErrorDTO.self, from: body),
+           let code = failure.error {
+            throw OAuthError.providerError(code: code, description: failure.error_description)
+        }
+        guard let dto = try? decoder.decode(DiscordTokenDTO.self, from: body),
+              let accessToken = dto.access_token else {
+            throw OAuthError.malformedTokenResponse("missing access_token")
+        }
+        return TokenSet(
+            accessToken: accessToken,
+            tokenType: dto.token_type ?? "Bearer",
+            refreshToken: dto.refresh_token,
+            scope: dto.scope,
+            expiresIn: dto.expires_in,
+            providerID: id
+        )
+    }
+
+    public func parseIdentity(_ body: Data) throws -> Identity {
+        guard let dto = try? JSONDecoder().decode(DiscordUserDTO.self, from: body) else {
+            throw OAuthError.malformedIdentityResponse("could not decode GET /users/@me")
+        }
+        return Identity(
+            providerID: id,
+            id: dto.id,
+            username: dto.username,
+            displayName: dto.global_name ?? dto.username
+        )
+    }
+}
+
+// MARK: - Discord response DTOs (internal)
+
+private struct DiscordTokenDTO: Decodable {
+    let access_token: String?
+    let token_type: String?
+    let expires_in: Int?
+    let refresh_token: String?
+    let scope: String?
+}
+
+private struct DiscordErrorDTO: Decodable {
+    let error: String?
+    let error_description: String?
+}
+
+private struct DiscordUserDTO: Decodable {
+    let id: String
+    let username: String
+    let global_name: String?
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Providers/GitHubProvider.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Providers/GitHubProvider.swift
@@ -1,0 +1,168 @@
+// Source: docs.github.com — "Authorizing OAuth apps" and "Refreshing user
+//   access tokens".
+//   https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps
+//   https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/refreshing-user-access-tokens
+//   Identity: GET https://api.github.com/user (requires a User-Agent header).
+//   Revoke:   DELETE https://api.github.com/applications/{client_id}/token
+//             (docs.github.com/en/rest/apps/oauth-applications#delete-an-app-token)
+import Foundation
+
+/// GitHub OAuth provider.
+///
+/// GitHub OAuth Apps authenticate the token exchange with a `client_secret`
+/// (a confidential client); GitHub does not implement PKCE for this flow, so
+/// `usesPKCE` is `false`. All endpoints below come from GitHub's own developer
+/// documentation (cited above) — not from any third-party port.
+public struct GitHubProvider: OAuthProvider, TokenRevocation {
+    public let id = "github"
+    public let usesPKCE = false
+    public let config: OAuthClientConfig
+
+    public init(config: OAuthClientConfig) {
+        self.config = config
+    }
+
+    private let authorizeEndpoint = URL(string: "https://github.com/login/oauth/authorize")!
+    private let tokenEndpoint = URL(string: "https://github.com/login/oauth/access_token")!
+    private let identityEndpoint = URL(string: "https://api.github.com/user")!
+
+    public func authorizeURL(state: String, codeChallenge: String?, redirectURI: URL) -> URL {
+        var components = URLComponents(url: authorizeEndpoint, resolvingAgainstBaseURL: false)!
+        var items = [
+            URLQueryItem(name: "client_id", value: config.clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI.absoluteString),
+            URLQueryItem(name: "state", value: state),
+        ]
+        if !config.scopes.isEmpty {
+            // GitHub uses space-delimited scopes.
+            items.append(URLQueryItem(name: "scope", value: config.scopes.joined(separator: " ")))
+        }
+        if let codeChallenge {
+            // GitHub ignores PKCE, but forwarding a challenge is a harmless no-op.
+            items.append(URLQueryItem(name: "code_challenge", value: codeChallenge))
+            items.append(URLQueryItem(name: "code_challenge_method", value: "S256"))
+        }
+        components.queryItems = items
+        return components.url!
+    }
+
+    public func tokenRequest(code: String, codeVerifier: String?, redirectURI: URL) -> HTTPRequest {
+        var fields = [
+            "client_id": config.clientID,
+            "code": code,
+            "redirect_uri": redirectURI.absoluteString,
+        ]
+        if let secret = config.clientSecret { fields["client_secret"] = secret }
+        if let codeVerifier { fields["code_verifier"] = codeVerifier }
+        // `Accept: application/json` makes GitHub return a JSON token body
+        // instead of the default form-encoded one.
+        return HTTPRequest.formPOST(
+            url: tokenEndpoint,
+            fields: fields,
+            headers: ["Accept": "application/json"]
+        )
+    }
+
+    public func refreshRequest(refreshToken: String) -> HTTPRequest {
+        var fields = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": config.clientID,
+        ]
+        if let secret = config.clientSecret { fields["client_secret"] = secret }
+        return HTTPRequest.formPOST(
+            url: tokenEndpoint,
+            fields: fields,
+            headers: ["Accept": "application/json"]
+        )
+    }
+
+    public func identityRequest(accessToken: String) -> HTTPRequest {
+        HTTPRequest(
+            method: .GET,
+            url: identityEndpoint,
+            headers: [
+                "Authorization": "Bearer \(accessToken)",
+                "Accept": "application/vnd.github+json",
+                // The GitHub REST API rejects requests without a User-Agent.
+                "User-Agent": "swiftoauth",
+            ]
+        )
+    }
+
+    // GitHub does NOT implement RFC 7009. An OAuth app revokes one of its tokens
+    // via DELETE /applications/{client_id}/token with HTTP Basic auth
+    // (client_id:client_secret) and a JSON body {"access_token": "..."}.
+    // Source: docs.github.com/en/rest/apps/oauth-applications#delete-an-app-token
+    // Returns nil without a client secret, which Basic auth requires.
+    public func revokeRequest(token: String, tokenTypeHint: TokenTypeHint) -> HTTPRequest? {
+        guard let secret = config.clientSecret, !secret.isEmpty else { return nil }
+        let url = URL(string: "https://api.github.com/applications/\(config.clientID)/token")!
+        let basic = Data("\(config.clientID):\(secret)".utf8).base64EncodedString()
+        let body = try? JSONSerialization.data(withJSONObject: ["access_token": token])
+        return HTTPRequest(
+            method: .DELETE,
+            url: url,
+            headers: [
+                "Authorization": "Basic \(basic)",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "swiftoauth",
+            ],
+            body: body
+        )
+    }
+
+    public func parseToken(_ body: Data) throws -> TokenSet {
+        let decoder = JSONDecoder()
+        // GitHub signals failures with a 200 + {"error": …} body, so check first.
+        if let failure = try? decoder.decode(GitHubErrorDTO.self, from: body),
+           let code = failure.error {
+            throw OAuthError.providerError(code: code, description: failure.error_description)
+        }
+        guard let dto = try? decoder.decode(GitHubTokenDTO.self, from: body),
+              let accessToken = dto.access_token else {
+            throw OAuthError.malformedTokenResponse("missing access_token")
+        }
+        return TokenSet(
+            accessToken: accessToken,
+            tokenType: dto.token_type ?? "bearer",
+            refreshToken: dto.refresh_token,
+            scope: dto.scope,
+            expiresIn: dto.expires_in,
+            providerID: id
+        )
+    }
+
+    public func parseIdentity(_ body: Data) throws -> Identity {
+        guard let dto = try? JSONDecoder().decode(GitHubUserDTO.self, from: body) else {
+            throw OAuthError.malformedIdentityResponse("could not decode GET /user")
+        }
+        return Identity(
+            providerID: id,
+            id: String(dto.id),
+            username: dto.login,
+            displayName: dto.name
+        )
+    }
+}
+
+// MARK: - GitHub response DTOs (internal)
+
+private struct GitHubTokenDTO: Decodable {
+    let access_token: String?
+    let token_type: String?
+    let scope: String?
+    let expires_in: Int?
+    let refresh_token: String?
+}
+
+private struct GitHubErrorDTO: Decodable {
+    let error: String?
+    let error_description: String?
+}
+
+private struct GitHubUserDTO: Decodable {
+    let id: Int
+    let login: String
+    let name: String?
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Providers/MastodonProvider.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Providers/MastodonProvider.swift
@@ -1,0 +1,199 @@
+// Source: docs.joinmastodon.org — OAuth and Apps.
+//   register:  POST {instance}/api/v1/apps            (docs.joinmastodon.org/methods/apps)
+//   authorize: {instance}/oauth/authorize             (docs.joinmastodon.org/spec/oauth)
+//   token:     POST {instance}/oauth/token
+//   identity:  GET {instance}/api/v1/accounts/verify_credentials
+//   revoke:    POST {instance}/oauth/revoke            (docs.joinmastodon.org/methods/oauth)
+//   PKCE: Mastodon supports the S256 code challenge for the authorization-code grant.
+//
+// Mastodon is per-instance: there is no single base URL. Every endpoint is
+// relative to the instance the user is signing in to, supplied via
+// `OAuthClientConfig.instanceBaseURL`. Each instance also issues its own
+// client credentials via dynamic app registration, hence `DynamicClientRegistration`.
+import Foundation
+
+public struct MastodonProvider: OAuthProvider, DynamicClientRegistration, TokenRevocation {
+    public let id = "mastodon"
+    public let usesPKCE = true
+    public let config: OAuthClientConfig
+
+    /// The instance base URL (e.g. `https://mastodon.social`). Required — the
+    /// supported construction path is `Providers.make`, which validates that
+    /// `config.instanceBaseURL` is present before reaching here.
+    public let baseURL: URL
+
+    public init(config: OAuthClientConfig) {
+        precondition(
+            config.instanceBaseURL != nil,
+            "MastodonProvider requires config.instanceBaseURL (use Providers.make for a validated error)"
+        )
+        self.config = config
+        self.baseURL = config.instanceBaseURL!
+    }
+
+    private func endpoint(_ path: String) -> URL {
+        var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)!
+        components.path = path
+        components.queryItems = nil
+        return components.url!
+    }
+
+    // MARK: - Dynamic app registration (docs.joinmastodon.org/methods/apps)
+
+    public func appRegistrationRequest(
+        clientName: String,
+        redirectURI: URL,
+        scopes: [String],
+        website: URL?
+    ) -> HTTPRequest {
+        var fields = [
+            "client_name": clientName,
+            "redirect_uris": redirectURI.absoluteString,
+            // Mastodon uses space-delimited scopes (e.g. "read write follow").
+            "scopes": (scopes.isEmpty ? ["read"] : scopes).joined(separator: " "),
+        ]
+        if let website { fields["website"] = website.absoluteString }
+        return HTTPRequest.formPOST(url: endpoint("/api/v1/apps"), fields: fields)
+    }
+
+    public func parseAppRegistration(_ body: Data) throws -> ClientCredentials {
+        guard let dto = try? JSONDecoder().decode(MastodonAppDTO.self, from: body),
+              let clientID = dto.client_id else {
+            throw OAuthError.malformedTokenResponse("could not decode POST /api/v1/apps")
+        }
+        return ClientCredentials(clientID: clientID, clientSecret: dto.client_secret)
+    }
+
+    // MARK: - OAuthProvider
+
+    public func authorizeURL(state: String, codeChallenge: String?, redirectURI: URL) -> URL {
+        var components = URLComponents(url: endpoint("/oauth/authorize"), resolvingAgainstBaseURL: false)!
+        var items = [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: config.clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI.absoluteString),
+            URLQueryItem(name: "state", value: state),
+        ]
+        if !config.scopes.isEmpty {
+            items.append(URLQueryItem(name: "scope", value: config.scopes.joined(separator: " ")))
+        }
+        if let codeChallenge {
+            items.append(URLQueryItem(name: "code_challenge", value: codeChallenge))
+            items.append(URLQueryItem(name: "code_challenge_method", value: "S256"))
+        }
+        components.queryItems = items
+        return components.url!
+    }
+
+    public func tokenRequest(code: String, codeVerifier: String?, redirectURI: URL) -> HTTPRequest {
+        var fields = [
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": config.clientID,
+            "redirect_uri": redirectURI.absoluteString,
+        ]
+        if let secret = config.clientSecret { fields["client_secret"] = secret }
+        if let codeVerifier { fields["code_verifier"] = codeVerifier }
+        if !config.scopes.isEmpty { fields["scope"] = config.scopes.joined(separator: " ") }
+        return HTTPRequest.formPOST(url: endpoint("/oauth/token"), fields: fields)
+    }
+
+    public func refreshRequest(refreshToken: String) -> HTTPRequest {
+        // Mastodon access tokens are long-lived and historically non-expiring;
+        // newer instances accept the standard refresh grant when a token does
+        // expire. We build the RFC 6749 §6 request either way.
+        var fields = [
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken,
+            "client_id": config.clientID,
+        ]
+        if let secret = config.clientSecret { fields["client_secret"] = secret }
+        return HTTPRequest.formPOST(url: endpoint("/oauth/token"), fields: fields)
+    }
+
+    public func identityRequest(accessToken: String) -> HTTPRequest {
+        HTTPRequest(
+            method: .GET,
+            url: endpoint("/api/v1/accounts/verify_credentials"),
+            headers: [
+                "Authorization": "Bearer \(accessToken)",
+                "Accept": "application/json",
+            ]
+        )
+    }
+
+    // RFC 7009 revocation: POST {instance}/oauth/revoke with the client
+    // credentials and the token. Source: docs.joinmastodon.org/methods/oauth
+    // (the "Revoke token" method). Returns nil without a client secret, which
+    // Mastodon's revocation requires.
+    public func revokeRequest(token: String, tokenTypeHint: TokenTypeHint) -> HTTPRequest? {
+        guard let secret = config.clientSecret, !secret.isEmpty else { return nil }
+        let fields = [
+            "client_id": config.clientID,
+            "client_secret": secret,
+            "token": token,
+        ]
+        return HTTPRequest.formPOST(url: endpoint("/oauth/revoke"), fields: fields)
+    }
+
+    public func parseToken(_ body: Data) throws -> TokenSet {
+        let decoder = JSONDecoder()
+        if let failure = try? decoder.decode(MastodonErrorDTO.self, from: body),
+           let code = failure.error {
+            throw OAuthError.providerError(code: code, description: failure.error_description)
+        }
+        guard let dto = try? decoder.decode(MastodonTokenDTO.self, from: body),
+              let accessToken = dto.access_token else {
+            throw OAuthError.malformedTokenResponse("missing access_token")
+        }
+        // Mastodon reports `created_at` (unix seconds) rather than `expires_in`;
+        // tokens are long-lived, so we leave `expiresIn` nil.
+        return TokenSet(
+            accessToken: accessToken,
+            tokenType: dto.token_type ?? "Bearer",
+            refreshToken: dto.refresh_token,
+            scope: dto.scope,
+            expiresIn: dto.expires_in,
+            providerID: id
+        )
+    }
+
+    public func parseIdentity(_ body: Data) throws -> Identity {
+        guard let dto = try? JSONDecoder().decode(MastodonAccountDTO.self, from: body) else {
+            throw OAuthError.malformedIdentityResponse("could not decode verify_credentials")
+        }
+        return Identity(
+            providerID: id,
+            id: dto.id,
+            username: dto.username ?? dto.acct,
+            displayName: dto.display_name
+        )
+    }
+}
+
+// MARK: - Mastodon response DTOs (internal)
+
+private struct MastodonAppDTO: Decodable {
+    let client_id: String?
+    let client_secret: String?
+}
+
+private struct MastodonTokenDTO: Decodable {
+    let access_token: String?
+    let token_type: String?
+    let scope: String?
+    let refresh_token: String?
+    let expires_in: Int?
+}
+
+private struct MastodonErrorDTO: Decodable {
+    let error: String?
+    let error_description: String?
+}
+
+private struct MastodonAccountDTO: Decodable {
+    let id: String
+    let username: String?
+    let acct: String
+    let display_name: String?
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/RandomBytes.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/RandomBytes.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Cryptographically secure random bytes.
+///
+/// Backed by `SystemRandomNumberGenerator`, which Swift documents as suitable
+/// for cryptographic use on every supported platform (it wraps the OS CSPRNG:
+/// `getrandom`/`/dev/urandom` on Linux, `arc4random` on Apple platforms,
+/// `BCryptGenRandom` on Windows). This keeps swiftoauth free of any Apple-only
+/// crypto RNG.
+public enum RandomBytes {
+    /// Return `count` cryptographically random bytes.
+    public static func generate(count: Int) -> [UInt8] {
+        precondition(count >= 0, "count must be non-negative")
+        var rng = SystemRandomNumberGenerator()
+        return (0..<count).map { _ in UInt8.random(in: UInt8.min...UInt8.max, using: &rng) }
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Redaction.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/Redaction.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Helpers that keep secrets out of logs and `description`s. swiftoauth never
+/// prints a raw token or `Authorization` header unless the user explicitly
+/// asks (e.g. `--show-token`).
+public enum Redaction {
+    /// The mask substituted for any redacted secret. ASCII so it renders
+    /// correctly when printed to a Windows console (legacy code pages).
+    public static let placeholder = "<redacted>"
+
+    /// Header names whose values must never be logged (matched case-insensitively).
+    public static let sensitiveHeaders: Set<String> = [
+        "authorization",
+        "cookie",
+        "set-cookie",
+        "proxy-authorization",
+    ]
+
+    /// Mask a token. With `keepingPrefix > 0`, the first few characters are
+    /// retained as a debugging hint while the secret remainder is masked.
+    public static func redactToken(_ token: String, keepingPrefix prefix: Int = 0) -> String {
+        guard prefix > 0, token.count > prefix else { return placeholder }
+        return String(token.prefix(prefix)) + "…" + placeholder
+    }
+
+    /// Return a copy of `headers` with the values of sensitive headers masked.
+    public static func redactHeaders(_ headers: [String: String]) -> [String: String] {
+        var output = headers
+        for key in headers.keys where sensitiveHeaders.contains(key.lowercased()) {
+            output[key] = placeholder
+        }
+        return output
+    }
+
+    /// Mask the secret values in a JSON token-response body so raw exchange
+    /// payloads are safe to log.
+    public static func redactTokenJSON(_ body: String) -> String {
+        var result = body
+        for field in ["access_token", "refresh_token", "id_token", "client_secret"] {
+            let pattern = "\"\(field)\"\\s*:\\s*\"[^\"]*\""
+            result = result.replacingOccurrences(
+                of: pattern,
+                with: "\"\(field)\":\"\(placeholder)\"",
+                options: .regularExpression
+            )
+        }
+        return result
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/TokenRevocation.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/TokenRevocation.swift
@@ -1,0 +1,22 @@
+// Source: RFC 7009 — OAuth 2.0 Token Revocation.
+//   Discord and Mastodon expose an RFC 7009-style revocation endpoint; GitHub
+//   instead revokes via its own DELETE-based REST call (cited in that provider's
+//   file). Each provider builds its own request — this protocol is the shared
+//   seam, kept a pure value transformation like the token and registration flows.
+import Foundation
+
+/// RFC 7009 §2.1 `token_type_hint`: which kind of token is being revoked.
+public enum TokenTypeHint: String, Sendable {
+    case accessToken = "access_token"
+    case refreshToken = "refresh_token"
+}
+
+/// A provider that can revoke a previously-issued token.
+///
+/// `revokeRequest` returns `nil` when revocation cannot be built from the
+/// current configuration (e.g. a provider whose revocation endpoint requires a
+/// client secret that isn't set). Callers treat `nil` as "revocation not
+/// available", never as an error to surface to the user mid-logout.
+public protocol TokenRevocation: OAuthProvider {
+    func revokeRequest(token: String, tokenTypeHint: TokenTypeHint) -> HTTPRequest?
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/TokenSet.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/TokenSet.swift
@@ -1,0 +1,65 @@
+// Source: RFC 6749 §5.1 (token response) + RFC 6750 §2.1 (bearer usage).
+import Foundation
+
+/// An OAuth 2.0 token response (RFC 6749 §5.1) plus the bookkeeping swiftoauth
+/// needs to persist and later refresh it.
+///
+/// `Codable` for the on-disk token store; `description` is overridden so the
+/// secret material is never printed by accident.
+public struct TokenSet: Codable, Sendable, Equatable {
+    public let accessToken: String
+    public let tokenType: String
+    public let refreshToken: String?
+    public let scope: String?
+    /// Lifetime in seconds as reported by the token response, if any.
+    public let expiresIn: Int?
+    /// When swiftoauth received the token (used to compute absolute expiry).
+    public let obtainedAt: Date
+    public let providerID: String
+
+    public init(
+        accessToken: String,
+        tokenType: String,
+        refreshToken: String? = nil,
+        scope: String? = nil,
+        expiresIn: Int? = nil,
+        obtainedAt: Date = Date(),
+        providerID: String
+    ) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+        self.refreshToken = refreshToken
+        self.scope = scope
+        self.expiresIn = expiresIn
+        self.obtainedAt = obtainedAt
+        self.providerID = providerID
+    }
+
+    /// Absolute expiry instant, if the response carried `expires_in`.
+    public var expiresAt: Date? {
+        expiresIn.map { obtainedAt.addingTimeInterval(TimeInterval($0)) }
+    }
+
+    /// Whether the access token is past expiry (within `leeway` seconds).
+    /// Tokens without an `expires_in` are treated as non-expiring here.
+    public func isExpired(now: Date = Date(), leeway: TimeInterval = 30) -> Bool {
+        guard let expiresAt else { return false }
+        return now.addingTimeInterval(leeway) >= expiresAt
+    }
+
+    /// The RFC 6750 bearer `Authorization` header value for this token.
+    public var authorizationHeader: String {
+        "Bearer \(accessToken)"
+    }
+}
+
+extension TokenSet: CustomStringConvertible {
+    /// Never prints secret material — access and refresh tokens are redacted.
+    public var description: String {
+        let expiry = expiresAt.map { String(describing: $0) } ?? "nil"
+        return "TokenSet(provider: \(providerID), tokenType: \(tokenType), "
+            + "accessToken: \(Redaction.redactToken(accessToken)), "
+            + "refreshToken: \(refreshToken.map { _ in Redaction.placeholder } ?? "nil"), "
+            + "scope: \(scope ?? "nil"), expiresAt: \(expiry))"
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/TokenStore.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthCore/TokenStore.swift
@@ -1,0 +1,97 @@
+// Token store — persists TokenSets to ~/.swiftoauth/tokens.json.
+//
+// Security posture:
+//  - The file is written with mode 0600 on POSIX platforms (owner read/write
+//    only). On Windows, POSIX mode bits do not apply; files created under
+//    %USERPROFILE%\.swiftoauth inherit that profile's ACL, which is already
+//    restricted to the user, SYSTEM, and Administrators. This is the documented
+//    Windows caveat — there is no world-readable exposure either way.
+//  - Tokens are NEVER logged. Callers decide whether to display them.
+//  - Writes go through a temp file + move so a crash cannot leave a truncated
+//    token file. (We avoid FileManager.replaceItemAt, which is unimplemented on
+//    Windows swift-corelibs-foundation.)
+import Foundation
+
+/// On-disk store for OAuth tokens, keyed by provider id.
+public struct TokenStore: Sendable {
+    /// Directory holding `tokens.json` (default `~/.swiftoauth`).
+    public let directory: URL
+    private let fileURL: URL
+
+    public init(directory: URL? = nil) {
+        let dir: URL
+        if let directory {
+            dir = directory
+        } else if let home = ProcessInfo.processInfo.environment["SWIFTOAUTH_HOME"], !home.isEmpty {
+            // Relocate the whole config dir, e.g. for tests or an isolated profile.
+            dir = URL(fileURLWithPath: home, isDirectory: true)
+                .appendingPathComponent(".swiftoauth", isDirectory: true)
+        } else {
+            dir = FileManager.default
+                .homeDirectoryForCurrentUser
+                .appendingPathComponent(".swiftoauth", isDirectory: true)
+        }
+        self.directory = dir
+        self.fileURL = dir.appendingPathComponent("tokens.json")
+    }
+
+    /// All stored tokens, keyed by provider id. Empty if the file is absent.
+    public func loadAll() throws -> [String: TokenSet] {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { return [:] }
+        let data = try Data(contentsOf: fileURL)
+        guard !data.isEmpty else { return [:] }
+        return try JSONDecoder().decode([String: TokenSet].self, from: data)
+    }
+
+    /// Load the token for one provider, or `nil` if none is stored.
+    public func load(providerID: String) throws -> TokenSet? {
+        try loadAll()[providerID]
+    }
+
+    /// Persist (or replace) the token for its provider.
+    public func save(_ token: TokenSet) throws {
+        var all = (try? loadAll()) ?? [:]
+        all[token.providerID] = token
+        try writeAll(all)
+    }
+
+    /// Remove the token for a provider. No-op if none is stored.
+    public func delete(providerID: String) throws {
+        var all = (try? loadAll()) ?? [:]
+        guard all.removeValue(forKey: providerID) != nil else { return }
+        try writeAll(all)
+    }
+
+    // MARK: - Private
+
+    private func writeAll(_ all: [String: TokenSet]) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        restrictPermissions(on: directory, isDirectory: true)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(all)
+
+        let tmp = directory.appendingPathComponent(
+            "tokens.json.tmp-\(ProcessInfo.processInfo.processIdentifier)"
+        )
+        try? FileManager.default.removeItem(at: tmp)
+        try data.write(to: tmp)
+        restrictPermissions(on: tmp, isDirectory: false)
+
+        if FileManager.default.fileExists(atPath: fileURL.path) {
+            try FileManager.default.removeItem(at: fileURL)
+        }
+        try FileManager.default.moveItem(at: tmp, to: fileURL)
+        restrictPermissions(on: fileURL, isDirectory: false)
+    }
+
+    /// Apply owner-only permissions where the platform supports POSIX modes.
+    private func restrictPermissions(on url: URL, isDirectory: Bool) {
+        #if !os(Windows)
+        let mode: NSNumber = isDirectory ? 0o700 : 0o600
+        try? FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: url.path)
+        #endif
+        // Windows: ACL inheritance from %USERPROFILE% (see file header).
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthServer/CallbackApplication.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthServer/CallbackApplication.swift
@@ -1,0 +1,39 @@
+// SwiftOAuthServer — Hummingbird application wrapper for the loopback server.
+//
+// We conform to `ApplicationProtocol` and call `run()` (NOT `runService()`):
+// `runService()` installs SIGTERM/SIGINT graceful-shutdown handlers that do not
+// exist on Windows. Shutting down is instead driven by Task cancellation from
+// `CallbackServer.run`. `onServerRunning` reports the actually-bound port so an
+// ephemeral `port: 0` request can be turned into a concrete redirect URI.
+import Foundation
+import Hummingbird
+import NIOCore
+
+struct CallbackApplication: ApplicationProtocol {
+    typealias Context = BasicRequestContext
+
+    // Store the already-built responder (which is `Sendable`), not the
+    // `Router` (which is not), so the application struct stays `Sendable`.
+    let appResponder: RouterResponder<Context>
+    let host: String
+    let port: Int
+    let onBound: @Sendable (Int) async -> Void
+
+    var configuration: ApplicationConfiguration {
+        .init(
+            address: .hostname(host, port: port),
+            serverName: "swiftoauth-callback"
+        )
+    }
+
+    var responder: some HTTPResponder<Context> {
+        appResponder
+    }
+
+    func onServerRunning(_ channel: any Channel) async {
+        // `port: 0` binds an ephemeral port; read the real one back off the
+        // bound channel so the caller can form the exact redirect URI.
+        let bound = channel.localAddress?.port ?? port
+        await onBound(bound)
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthServer/CallbackServer.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthServer/CallbackServer.swift
@@ -1,0 +1,178 @@
+// SwiftOAuthServer — loopback OAuth callback server (RFC 8252 §7.3).
+//
+// Captures exactly one authorization-code redirect on 127.0.0.1, validates the
+// CSRF `state` (RFC 6749 §10.12) with a constant-time exact match, serves a
+// "you may close this tab" page, and shuts the server down. No TLS is involved
+// (loopback only) — and there is deliberately no insecure escape hatch.
+import Foundation
+import Hummingbird
+import NIOCore
+import SwiftOAuthCore
+
+/// A one-shot loopback server that waits for a single OAuth callback.
+public final class CallbackServer: Sendable {
+    private let config: CallbackServerConfig
+
+    public init(config: CallbackServerConfig) {
+        self.config = config
+    }
+
+    /// One-shot latch holding the bound port and the awaited callback outcome,
+    /// each delivered exactly once across the server task and the request
+    /// handler.
+    private actor Latch {
+        private var portContinuation: CheckedContinuation<Int, Never>?
+        private var portValue: Int?
+        private var outcomeContinuation: CheckedContinuation<CallbackOutcome, Never>?
+        private var outcomeValue: CallbackOutcome?
+
+        func waitForPort() async -> Int {
+            if let portValue { return portValue }
+            return await withCheckedContinuation { portContinuation = $0 }
+        }
+
+        func resolvePort(_ port: Int) {
+            guard portValue == nil else { return }
+            portValue = port
+            portContinuation?.resume(returning: port)
+            portContinuation = nil
+        }
+
+        func waitForOutcome() async -> CallbackOutcome {
+            if let outcomeValue { return outcomeValue }
+            return await withCheckedContinuation { outcomeContinuation = $0 }
+        }
+
+        /// Resolve the outcome exactly once; later callbacks are ignored.
+        /// Returns true if this call is the one that resolved it.
+        @discardableResult
+        func resolveOutcome(_ outcome: CallbackOutcome) -> Bool {
+            guard outcomeValue == nil else { return false }
+            outcomeValue = outcome
+            outcomeContinuation?.resume(returning: outcome)
+            outcomeContinuation = nil
+            return true
+        }
+    }
+
+    /// The result of running the callback server.
+    public struct RunResult: Sendable {
+        public let outcome: CallbackOutcome
+        /// The port the server actually bound (useful when `config.port == 0`).
+        public let boundPort: Int
+        /// The exact loopback redirect URI the provider redirected to.
+        public let redirectURI: URL
+    }
+
+    /// Start the loopback server, block until one callback is captured (or the
+    /// task is cancelled), then shut down and return the outcome.
+    ///
+    /// - Parameter onBound: invoked with the exact loopback redirect URI once
+    ///   the server is listening — the caller opens the browser to the
+    ///   provider's authorize URL built with this redirect URI.
+    public func run(
+        onBound: (@Sendable (URL) async -> Void)? = nil
+    ) async throws -> RunResult {
+        let latch = Latch()
+        let config = self.config
+
+        let router = Router()
+        router.get(RouterPath(config.path)) { request, _ -> Response in
+            let outcome = Self.classify(query: request.uri.queryParameters, expectedState: config.expectedState)
+            await latch.resolveOutcome(outcome)
+            return Self.htmlResponse(for: outcome, successHTML: config.successHTML)
+        }
+
+        let app = CallbackApplication(
+            appResponder: router.buildResponder(),
+            host: config.host,
+            port: config.port,
+            onBound: { port in await latch.resolvePort(port) }
+        )
+
+        return try await withThrowingTaskGroup(of: RunResult?.self) { group in
+            // Server task: runs until cancelled.
+            group.addTask {
+                try await app.run()
+                return nil
+            }
+            // Driver task: wait for bind, fire onBound, await the one callback.
+            group.addTask {
+                let port = await latch.waitForPort()
+                let redirectURI = config.redirectURI(boundPort: port)
+                if let onBound { await onBound(redirectURI) }
+                let outcome = await latch.waitForOutcome()
+                return RunResult(outcome: outcome, boundPort: port, redirectURI: redirectURI)
+            }
+
+            // The driver task produces the result; cancel the server once we have it.
+            var result: RunResult?
+            for try await value in group {
+                if let value {
+                    result = value
+                    group.cancelAll()
+                    break
+                }
+            }
+            return result!
+        }
+    }
+
+    // MARK: - Pure helpers (unit-tested directly)
+
+    /// Classify a callback's query parameters into an outcome.
+    ///
+    /// `state` is checked first with a constant-time exact comparison; any
+    /// mismatch is rejected before `code`/`error` are even considered.
+    static func classify(
+        query: some Sequence<(key: Substring, value: Substring)>,
+        expectedState: String
+    ) -> CallbackOutcome {
+        var params: [String: String] = [:]
+        for (key, value) in query {
+            params[String(key)] = String(value)
+        }
+        // CSRF: the returned state must be present and an exact match.
+        guard let returnedState = params["state"],
+              ConstantTime.equals(expectedState, returnedState) else {
+            return .stateMismatch
+        }
+        if let error = params["error"] {
+            return .providerError(error: error, description: params["error_description"])
+        }
+        if let code = params["code"], !code.isEmpty {
+            return .code(code)
+        }
+        return .missingParameters
+    }
+
+    private static func htmlResponse(for outcome: CallbackOutcome, successHTML: String) -> Response {
+        let (status, html): (HTTPResponse.Status, String)
+        switch outcome {
+        case .code:
+            (status, html) = (.ok, successHTML)
+        case .stateMismatch:
+            (status, html) = (.badRequest, Self.errorHTML("State mismatch — request rejected."))
+        case .providerError(let error, let description):
+            (status, html) = (.badRequest, Self.errorHTML("Authorization failed: \(error)" + (description.map { " — \($0)" } ?? "")))
+        case .missingParameters:
+            (status, html) = (.badRequest, Self.errorHTML("Callback was missing the authorization code."))
+        }
+        var buffer = ByteBuffer()
+        buffer.writeString(html)
+        var headers = HTTPFields()
+        headers[.contentType] = "text/html; charset=utf-8"
+        return Response(status: status, headers: headers, body: .init(byteBuffer: buffer))
+    }
+
+    private static func errorHTML(_ message: String) -> String {
+        """
+        <!doctype html><html><head><meta charset="utf-8">\
+        <title>swiftoauth</title></head>\
+        <body style="font-family:system-ui;margin:3rem">\
+        <h1>Authentication error</h1>\
+        <p>\(message)</p>\
+        </body></html>
+        """
+    }
+}

--- a/source/ios-swift-swiftoauth/Sources/SwiftOAuthServer/CallbackTypes.swift
+++ b/source/ios-swift-swiftoauth/Sources/SwiftOAuthServer/CallbackTypes.swift
@@ -1,0 +1,62 @@
+// Source: RFC 6749 §4.1.2 (authorization response) / §4.1.2.1 (error response)
+//         + RFC 8252 §7.3 (loopback redirect on 127.0.0.1).
+import Foundation
+import SwiftOAuthCore
+
+/// The outcome of the one callback the loopback server is waiting for.
+public enum CallbackOutcome: Sendable, Equatable {
+    /// The provider redirected back with a valid, state-matched authorization
+    /// code (RFC 6749 §4.1.2).
+    case code(String)
+    /// The provider redirected back with an OAuth error (RFC 6749 §4.1.2.1).
+    case providerError(error: String, description: String?)
+    /// The redirect's `state` did not match (possible CSRF) — rejected.
+    case stateMismatch
+    /// The redirect carried neither a `code` nor an `error`.
+    case missingParameters
+}
+
+/// Configuration for a single loopback authorization callback.
+public struct CallbackServerConfig: Sendable {
+    /// Loopback host. Per RFC 8252 §8.3 this binds the literal IP `127.0.0.1`,
+    /// NOT the hostname "localhost".
+    public let host: String
+    /// TCP port. `0` asks the OS for an ephemeral port; the bound port is then
+    /// reported back via ``CallbackServer/boundPort``.
+    public let port: Int
+    /// The exact callback path the server answers; any other path 404s.
+    public let path: String
+    /// The CSRF `state` value this callback must match exactly.
+    public let expectedState: String
+    /// HTML served to the browser after the callback is captured.
+    public let successHTML: String
+
+    public init(
+        host: String = "127.0.0.1",
+        port: Int = 0,
+        path: String = "/callback",
+        expectedState: String,
+        successHTML: String = CallbackServerConfig.defaultSuccessHTML
+    ) {
+        self.host = host
+        self.port = port
+        self.path = path
+        self.expectedState = expectedState
+        self.successHTML = successHTML
+    }
+
+    /// The exact loopback redirect URI for a given bound port — the value that
+    /// must be sent as `redirect_uri` and registered with the provider.
+    public func redirectURI(boundPort: Int) -> URL {
+        URL(string: "http://\(host):\(boundPort)\(path)")!
+    }
+
+    public static let defaultSuccessHTML = """
+    <!doctype html><html><head><meta charset="utf-8">\
+    <title>swiftoauth</title></head>\
+    <body style="font-family:system-ui;margin:3rem">\
+    <h1>Authentication complete</h1>\
+    <p>You may close this tab and return to the terminal.</p>\
+    </body></html>
+    """
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/Base64URLTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/Base64URLTests.swift
@@ -1,0 +1,37 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+@Suite struct Base64URLTests {
+    /// RFC 4648 §10 test vectors, rendered as unpadded base64url.
+    @Test func rfc4648Vectors() {
+        #expect(Base64URL.encode(Data("".utf8)) == "")
+        #expect(Base64URL.encode(Data("f".utf8)) == "Zg")
+        #expect(Base64URL.encode(Data("fo".utf8)) == "Zm8")
+        #expect(Base64URL.encode(Data("foo".utf8)) == "Zm9v")
+        #expect(Base64URL.encode(Data("foob".utf8)) == "Zm9vYg")
+        #expect(Base64URL.encode(Data("fooba".utf8)) == "Zm9vYmE")
+        #expect(Base64URL.encode(Data("foobar".utf8)) == "Zm9vYmFy")
+    }
+
+    @Test func neverEmitsPadding() {
+        for n in 0..<40 {
+            #expect(!Base64URL.encode(RandomBytes.generate(count: n)).contains("="))
+        }
+    }
+
+    @Test func usesUrlSafeAlphabetOnly() {
+        for n in 0..<40 {
+            let encoded = Base64URL.encode(RandomBytes.generate(count: n))
+            #expect(!encoded.contains("+"))
+            #expect(!encoded.contains("/"))
+        }
+    }
+
+    @Test func roundTripsThroughDecode() {
+        for n in 0..<64 {
+            let bytes = RandomBytes.generate(count: n)
+            #expect(Base64URL.decode(Base64URL.encode(bytes)) == Data(bytes))
+        }
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/DiscordMastodonProviderTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/DiscordMastodonProviderTests.swift
@@ -1,0 +1,197 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+private func query(_ url: URL) -> [String: String] {
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    return Dictionary(items.map { ($0.name, $0.value ?? "") }, uniquingKeysWith: { first, _ in first })
+}
+
+@Suite struct DiscordProviderTests {
+    private let config = OAuthClientConfig(clientID: "CID", clientSecret: "SECRET", scopes: ["identify", "email"])
+    private var provider: DiscordProvider { DiscordProvider(config: config) }
+    private let redirect = URL(string: "http://127.0.0.1:8080/callback")!
+
+    @Test func identityAndFlags() {
+        #expect(provider.id == "discord")
+        #expect(provider.usesPKCE == true)
+    }
+
+    @Test func authorizeURLShape() {
+        let url = provider.authorizeURL(state: "STATE", codeChallenge: "CHAL", redirectURI: redirect)
+        #expect(url.absoluteString.hasPrefix("https://discord.com/oauth2/authorize?"))
+        let q = query(url)
+        #expect(q["response_type"] == "code")
+        #expect(q["client_id"] == "CID")
+        #expect(q["redirect_uri"] == "http://127.0.0.1:8080/callback")
+        #expect(q["state"] == "STATE")
+        #expect(q["scope"] == "identify email")   // space-delimited
+        #expect(q["code_challenge"] == "CHAL")
+        #expect(q["code_challenge_method"] == "S256")
+    }
+
+    @Test func tokenRequestShape() {
+        let request = provider.tokenRequest(code: "THECODE", codeVerifier: "VERIFIER", redirectURI: redirect)
+        #expect(request.method == .POST)
+        #expect(request.url.absoluteString == "https://discord.com/api/oauth2/token")
+        #expect(request.headers["Content-Type"] == "application/x-www-form-urlencoded")
+        let body = String(decoding: request.body ?? Data(), as: UTF8.self)
+        #expect(body.contains("grant_type=authorization_code"))
+        #expect(body.contains("code=THECODE"))
+        #expect(body.contains("client_id=CID"))
+        #expect(body.contains("client_secret=SECRET"))
+        #expect(body.contains("code_verifier=VERIFIER"))
+    }
+
+    @Test func refreshRequestShape() {
+        let body = String(decoding: provider.refreshRequest(refreshToken: "rt").body ?? Data(), as: UTF8.self)
+        #expect(body.contains("grant_type=refresh_token"))
+        #expect(body.contains("refresh_token=rt"))
+        #expect(body.contains("client_id=CID"))
+    }
+
+    @Test func identityRequestShape() {
+        let request = provider.identityRequest(accessToken: "TOKEN")
+        #expect(request.method == .GET)
+        #expect(request.url.absoluteString == "https://discord.com/api/users/@me")
+        #expect(request.headers["Authorization"] == "Bearer TOKEN")
+    }
+
+    // Recorded fixture — Discord token response.
+    @Test func parseTokenFromFixture() throws {
+        let body = Data(#"{"access_token":"dc_FIX","token_type":"Bearer","expires_in":604800,"refresh_token":"dc_R","scope":"identify email"}"#.utf8)
+        let token = try provider.parseToken(body)
+        #expect(token.accessToken == "dc_FIX")
+        #expect(token.tokenType == "Bearer")
+        #expect(token.refreshToken == "dc_R")
+        #expect(token.expiresIn == 604800)
+        #expect(token.providerID == "discord")
+    }
+
+    @Test func parseTokenErrorThrows() {
+        let body = Data(#"{"error":"invalid_grant","error_description":"Invalid code"}"#.utf8)
+        #expect(throws: OAuthError.self) { try provider.parseToken(body) }
+    }
+
+    // Recorded fixture — Discord GET /users/@me.
+    @Test func parseIdentityFromFixture() throws {
+        let body = Data(#"{"id":"80351110224678912","username":"nelly","global_name":"Nelly","discriminator":"0"}"#.utf8)
+        let identity = try provider.parseIdentity(body)
+        #expect(identity.id == "80351110224678912")
+        #expect(identity.username == "nelly")
+        #expect(identity.displayName == "Nelly")
+    }
+
+    @Test func parseIdentityFallsBackToUsername() throws {
+        let body = Data(#"{"id":"1","username":"plain"}"#.utf8)
+        #expect(try provider.parseIdentity(body).displayName == "plain")
+    }
+}
+
+@Suite struct MastodonProviderTests {
+    private let instance = URL(string: "https://mastodon.example")!
+    private var config: OAuthClientConfig {
+        OAuthClientConfig(clientID: "CID", clientSecret: "SECRET", scopes: ["read", "write"], instanceBaseURL: instance)
+    }
+    private var provider: MastodonProvider { MastodonProvider(config: config) }
+    private let redirect = URL(string: "http://127.0.0.1:8080/callback")!
+
+    @Test func identityAndFlags() {
+        #expect(provider.id == "mastodon")
+        #expect(provider.usesPKCE == true)
+        #expect(provider.baseURL == instance)
+    }
+
+    @Test func endpointsAreInstanceRelative() {
+        let auth = provider.authorizeURL(state: "S", codeChallenge: nil, redirectURI: redirect)
+        #expect(auth.absoluteString.hasPrefix("https://mastodon.example/oauth/authorize?"))
+        #expect(provider.tokenRequest(code: "c", codeVerifier: nil, redirectURI: redirect)
+            .url.absoluteString == "https://mastodon.example/oauth/token")
+        #expect(provider.identityRequest(accessToken: "t")
+            .url.absoluteString == "https://mastodon.example/api/v1/accounts/verify_credentials")
+    }
+
+    @Test func authorizeURLShape() {
+        let url = provider.authorizeURL(state: "STATE", codeChallenge: "CHAL", redirectURI: redirect)
+        let q = query(url)
+        #expect(q["response_type"] == "code")
+        #expect(q["client_id"] == "CID")
+        #expect(q["scope"] == "read write")
+        #expect(q["code_challenge"] == "CHAL")
+        #expect(q["code_challenge_method"] == "S256")
+    }
+
+    @Test func appRegistrationRequestShape() {
+        let request = provider.appRegistrationRequest(
+            clientName: "swiftoauth", redirectURI: redirect, scopes: ["read", "write"],
+            website: URL(string: "https://example.org")
+        )
+        #expect(request.method == .POST)
+        #expect(request.url.absoluteString == "https://mastodon.example/api/v1/apps")
+        let body = String(decoding: request.body ?? Data(), as: UTF8.self)
+        #expect(body.contains("client_name=swiftoauth"))
+        #expect(body.contains("scopes=read%20write"))
+        #expect(body.contains("redirect_uris="))
+        #expect(body.contains("website="))
+    }
+
+    // Recorded fixture — Mastodon POST /api/v1/apps.
+    @Test func parseAppRegistrationFromFixture() throws {
+        let body = Data(#"{"id":"123","name":"swiftoauth","client_id":"mc_ID","client_secret":"mc_SECRET","vapid_key":"x"}"#.utf8)
+        let creds = try provider.parseAppRegistration(body)
+        #expect(creds.clientID == "mc_ID")
+        #expect(creds.clientSecret == "mc_SECRET")
+    }
+
+    @Test func tokenRequestIncludesScope() {
+        let body = String(decoding: provider.tokenRequest(code: "c", codeVerifier: "v", redirectURI: redirect).body ?? Data(), as: UTF8.self)
+        #expect(body.contains("grant_type=authorization_code"))
+        #expect(body.contains("code_verifier=v"))
+        #expect(body.contains("scope=read%20write"))
+    }
+
+    // Recorded fixture — Mastodon token (no expires_in; long-lived).
+    @Test func parseTokenFromFixture() throws {
+        let body = Data(#"{"access_token":"ms_FIX","token_type":"Bearer","scope":"read write","created_at":1573979017}"#.utf8)
+        let token = try provider.parseToken(body)
+        #expect(token.accessToken == "ms_FIX")
+        #expect(token.tokenType == "Bearer")
+        #expect(token.scope == "read write")
+        #expect(token.expiresIn == nil)
+        #expect(token.expiresAt == nil)
+        #expect(token.providerID == "mastodon")
+    }
+
+    // Recorded fixture — Mastodon GET /verify_credentials.
+    @Test func parseIdentityFromFixture() throws {
+        let body = Data(#"{"id":"14715","username":"trwnh","acct":"trwnh","display_name":"infinite love"}"#.utf8)
+        let identity = try provider.parseIdentity(body)
+        #expect(identity.id == "14715")
+        #expect(identity.username == "trwnh")
+        #expect(identity.displayName == "infinite love")
+    }
+}
+
+@Suite struct ProviderRegistryDiscordMastodonTests {
+    @Test func knownIDsContainsAllThree() {
+        #expect(Providers.knownIDs == ["github", "discord", "mastodon"])
+    }
+
+    @Test func makeDiscord() throws {
+        let provider = try Providers.make(id: "discord", config: OAuthClientConfig(clientID: "x"))
+        #expect(provider.id == "discord")
+    }
+
+    @Test func makeMastodonRequiresInstance() {
+        // Without an instance URL, construction throws a clean config error.
+        #expect(throws: OAuthError.self) {
+            _ = try Providers.make(id: "mastodon", config: OAuthClientConfig(clientID: "x"))
+        }
+    }
+
+    @Test func makeMastodonWithInstance() throws {
+        let config = OAuthClientConfig(clientID: "x", instanceBaseURL: URL(string: "https://mastodon.social"))
+        let provider = try Providers.make(id: "mastodon", config: config)
+        #expect(provider.id == "mastodon")
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/GitHubProviderTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/GitHubProviderTests.swift
@@ -1,0 +1,129 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+@Suite struct GitHubProviderTests {
+    private let config = OAuthClientConfig(
+        clientID: "CID", clientSecret: "SECRET", scopes: ["read:user", "user:email"]
+    )
+    private var provider: GitHubProvider { GitHubProvider(config: config) }
+    private let redirect = URL(string: "http://127.0.0.1:8080/callback")!
+
+    private func query(_ url: URL) -> [String: String] {
+        let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        return Dictionary(items.map { ($0.name, $0.value ?? "") }, uniquingKeysWith: { first, _ in first })
+    }
+
+    @Test func identityAndFlags() {
+        #expect(provider.id == "github")
+        #expect(provider.usesPKCE == false)
+    }
+
+    @Test func authorizeURLShape() {
+        let url = provider.authorizeURL(state: "STATE", codeChallenge: nil, redirectURI: redirect)
+        #expect(url.absoluteString.hasPrefix("https://github.com/login/oauth/authorize?"))
+        let q = query(url)
+        #expect(q["client_id"] == "CID")
+        #expect(q["redirect_uri"] == "http://127.0.0.1:8080/callback")
+        #expect(q["state"] == "STATE")
+        #expect(q["scope"] == "read:user user:email")  // space-delimited
+        #expect(q["code_challenge"] == nil)
+    }
+
+    @Test func authorizeURLIncludesPKCEWhenProvided() {
+        let url = provider.authorizeURL(state: "S", codeChallenge: "CHALLENGE", redirectURI: redirect)
+        let q = query(url)
+        #expect(q["code_challenge"] == "CHALLENGE")
+        #expect(q["code_challenge_method"] == "S256")
+    }
+
+    @Test func tokenRequestShape() {
+        let request = provider.tokenRequest(code: "THECODE", codeVerifier: nil, redirectURI: redirect)
+        #expect(request.method == .POST)
+        #expect(request.url.absoluteString == "https://github.com/login/oauth/access_token")
+        #expect(request.headers["Accept"] == "application/json")
+        let body = String(decoding: request.body ?? Data(), as: UTF8.self)
+        #expect(body.contains("client_id=CID"))
+        #expect(body.contains("client_secret=SECRET"))
+        #expect(body.contains("code=THECODE"))
+        #expect(body.contains("redirect_uri="))
+    }
+
+    @Test func refreshRequestShape() {
+        let request = provider.refreshRequest(refreshToken: "ghr_x")
+        let body = String(decoding: request.body ?? Data(), as: UTF8.self)
+        #expect(body.contains("grant_type=refresh_token"))
+        #expect(body.contains("refresh_token=ghr_x"))
+        #expect(body.contains("client_id=CID"))
+    }
+
+    @Test func identityRequestShape() {
+        let request = provider.identityRequest(accessToken: "TOKEN")
+        #expect(request.method == .GET)
+        #expect(request.url.absoluteString == "https://api.github.com/user")
+        #expect(request.headers["Authorization"] == "Bearer TOKEN")
+        #expect(request.headers["User-Agent"] == "swiftoauth")
+        #expect(request.headers["Accept"] == "application/vnd.github+json")
+    }
+
+    // Recorded fixture — GitHub OAuth App token response (no live call).
+    @Test func parseTokenFromFixture() throws {
+        let body = Data(#"{"access_token":"gho_FIXTURE","token_type":"bearer","scope":"read:user,user:email"}"#.utf8)
+        let token = try provider.parseToken(body)
+        #expect(token.accessToken == "gho_FIXTURE")
+        #expect(token.tokenType == "bearer")
+        #expect(token.scope == "read:user,user:email")
+        #expect(token.providerID == "github")
+        #expect(token.refreshToken == nil)
+    }
+
+    // Recorded fixture — GitHub App expiring-token response with refresh.
+    @Test func parseTokenWithRefreshAndExpiry() throws {
+        let body = Data(#"{"access_token":"gho_x","token_type":"bearer","scope":"repo","expires_in":28800,"refresh_token":"ghr_FIXTURE"}"#.utf8)
+        let token = try provider.parseToken(body)
+        #expect(token.refreshToken == "ghr_FIXTURE")
+        #expect(token.expiresIn == 28800)
+    }
+
+    // Recorded fixture — GitHub returns 200 + {"error": …} on a bad code.
+    @Test func parseTokenErrorThrowsProviderError() {
+        let body = Data(#"{"error":"bad_verification_code","error_description":"The code passed is incorrect or expired."}"#.utf8)
+        #expect(throws: OAuthError.self) { try provider.parseToken(body) }
+    }
+
+    @Test func parseTokenGarbageThrows() {
+        #expect(throws: OAuthError.self) { try provider.parseToken(Data("not json".utf8)) }
+    }
+
+    // Recorded fixture — GET /user response.
+    @Test func parseIdentityFromFixture() throws {
+        let body = Data(#"{"login":"octocat","id":583231,"name":"The Octocat","type":"User"}"#.utf8)
+        let identity = try provider.parseIdentity(body)
+        #expect(identity.providerID == "github")
+        #expect(identity.id == "583231")
+        #expect(identity.username == "octocat")
+        #expect(identity.displayName == "The Octocat")
+    }
+
+    @Test func parseIdentityMissingFieldsThrows() {
+        #expect(throws: OAuthError.self) { try provider.parseIdentity(Data("{}".utf8)) }
+    }
+}
+
+@Suite struct ProviderRegistryTests {
+    @Test func knownIDsContainsGitHub() {
+        #expect(Providers.knownIDs.contains("github"))
+    }
+
+    @Test func makeGitHubProvider() throws {
+        let provider = try Providers.make(id: "github", config: OAuthClientConfig(clientID: "x"))
+        #expect(provider.id == "github")
+        #expect(provider.usesPKCE == false)
+    }
+
+    @Test func makeUnknownThrows() {
+        #expect(throws: OAuthError.self) {
+            _ = try Providers.make(id: "nope", config: OAuthClientConfig(clientID: "x"))
+        }
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/OAuthClientTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/OAuthClientTests.swift
@@ -1,0 +1,92 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+/// A transport that returns a canned response and records what it was asked to
+/// send — so the OAuth flows can be exercised without any network access.
+private actor FakeTransport: OAuthTransport {
+    private let response: OAuthHTTPResponse
+    private(set) var lastRequest: HTTPRequest?
+
+    init(status: Int, body: String) {
+        self.response = OAuthHTTPResponse(status: status, body: Data(body.utf8))
+    }
+
+    func send(_ request: HTTPRequest) async throws -> OAuthHTTPResponse {
+        lastRequest = request
+        return response
+    }
+
+    func recordedRequest() -> HTTPRequest? { lastRequest }
+}
+
+@Suite struct OAuthClientTests {
+    private let config = OAuthClientConfig(clientID: "CID", clientSecret: "SECRET", scopes: ["read:user"])
+    private var github: GitHubProvider { GitHubProvider(config: config) }
+    private let redirect = URL(string: "http://127.0.0.1:8080/callback")!
+
+    @Test func exchangeAuthorizationCodeParsesToken() async throws {
+        let transport = FakeTransport(
+            status: 200,
+            body: #"{"access_token":"gho_FIX","token_type":"bearer","scope":"read:user"}"#
+        )
+        let client = OAuthClient(transport: transport)
+        let token = try await client.exchangeAuthorizationCode(
+            provider: github, code: "THECODE", codeVerifier: nil, redirectURI: redirect
+        )
+        #expect(token.accessToken == "gho_FIX")
+        #expect(token.providerID == "github")
+
+        // The transport saw the provider's token request.
+        let sent = await transport.recordedRequest()
+        #expect(sent?.method == .POST)
+        #expect(sent?.url.absoluteString == "https://github.com/login/oauth/access_token")
+    }
+
+    @Test func refreshParsesToken() async throws {
+        let transport = FakeTransport(
+            status: 200,
+            body: #"{"access_token":"gho_NEW","token_type":"bearer","refresh_token":"ghr_NEW"}"#
+        )
+        let client = OAuthClient(transport: transport)
+        let token = try await client.refresh(provider: github, refreshToken: "ghr_OLD")
+        #expect(token.accessToken == "gho_NEW")
+        #expect(token.refreshToken == "ghr_NEW")
+    }
+
+    @Test func fetchIdentityParsesIdentity() async throws {
+        let transport = FakeTransport(
+            status: 200,
+            body: #"{"login":"octocat","id":583231,"name":"The Octocat"}"#
+        )
+        let client = OAuthClient(transport: transport)
+        let identity = try await client.fetchIdentity(provider: github, accessToken: "gho_x")
+        #expect(identity.username == "octocat")
+        #expect(identity.id == "583231")
+    }
+
+    @Test func nonSuccessStatusThrowsProviderError() async throws {
+        let transport = FakeTransport(status: 401, body: #"{"message":"Bad credentials"}"#)
+        let client = OAuthClient(transport: transport)
+        await #expect(throws: OAuthError.self) {
+            _ = try await client.fetchIdentity(provider: github, accessToken: "bad")
+        }
+    }
+
+    @Test func errorBodyIsRedactedInThrownError() async throws {
+        // A non-2xx body that happens to contain a token must be redacted.
+        let transport = FakeTransport(
+            status: 400,
+            body: #"{"error":"x","access_token":"LEAKED"}"#
+        )
+        let client = OAuthClient(transport: transport)
+        do {
+            _ = try await client.exchangeAuthorizationCode(
+                provider: github, code: "c", codeVerifier: nil, redirectURI: redirect
+            )
+            Issue.record("expected an error")
+        } catch let error as OAuthError {
+            #expect(!"\(error)".contains("LEAKED"))
+        }
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/OAuthStateTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/OAuthStateTests.swift
@@ -1,0 +1,45 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+@Suite struct OAuthStateTests {
+    @Test func generatedStateDefaultLengthIs43() {
+        #expect(OAuthState.generate().value.count == 43)  // 32 bytes → 43 base64url chars
+    }
+
+    @Test func generatedStateIsUrlSafe() {
+        let value = OAuthState.generate().value
+        #expect(!value.contains("="))
+        #expect(!value.contains("+"))
+        #expect(!value.contains("/"))
+    }
+
+    @Test func matchesExactValue() {
+        #expect(OAuthState(value: "abc123").matches("abc123"))
+    }
+
+    @Test func rejectsMismatch() {
+        let state = OAuthState(value: "abc123")
+        #expect(!state.matches("abc124"))  // same length, different content
+        #expect(!state.matches("abc12"))   // shorter
+        #expect(!state.matches(""))        // empty
+    }
+
+    @Test func generatedStatesAreUnique() {
+        var seen = Set<String>()
+        for _ in 0..<1000 {
+            let value = OAuthState.generate().value
+            #expect(!seen.contains(value))
+            seen.insert(value)
+        }
+    }
+}
+
+@Suite struct ConstantTimeTests {
+    @Test func equalsHandlesEqualUnequalAndLengths() {
+        #expect(ConstantTime.equals("hello", "hello"))
+        #expect(ConstantTime.equals("", ""))
+        #expect(!ConstantTime.equals("hello", "world"))
+        #expect(!ConstantTime.equals("hello", "hell"))  // differing length
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/PKCETests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/PKCETests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+@Suite struct PKCETests {
+    /// RFC 7636 Appendix B: the canonical S256 verifier → challenge vector.
+    @Test func rfc7636AppendixBVector() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        #expect(PKCE.challenge(for: verifier) == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+    }
+
+    @Test func initComputesAppendixBChallenge() {
+        let pkce = PKCE(codeVerifier: "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk")
+        #expect(pkce.codeChallenge == "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM")
+        #expect(pkce.method == "S256")
+    }
+
+    @Test func generatedVerifierIsValidAndS256() {
+        let pkce = PKCE.generate()
+        #expect(PKCE.isValidVerifier(pkce.codeVerifier))
+        #expect(pkce.method == "S256")
+    }
+
+    @Test func defaultVerifierIs43Chars() {
+        #expect(PKCE.generate().codeVerifier.count == 43)
+    }
+
+    @Test func maxEntropyVerifierIs128Chars() {
+        #expect(PKCE.generate(verifierByteCount: 96).codeVerifier.count == 128)
+    }
+
+    @Test func challengeIsUnpaddedUrlSafe43() {
+        let challenge = PKCE.generate().codeChallenge
+        #expect(challenge.count == 43)  // SHA-256 → 32 bytes → 43 base64url chars
+        #expect(!challenge.contains("="))
+        #expect(!challenge.contains("+"))
+        #expect(!challenge.contains("/"))
+    }
+
+    @Test func verifiersAreUnique() {
+        #expect(PKCE.generate().codeVerifier != PKCE.generate().codeVerifier)
+    }
+
+    @Test func isValidVerifierRejectsBadInput() {
+        #expect(PKCE.isValidVerifier("dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"))
+        #expect(!PKCE.isValidVerifier("tooshort"))
+        #expect(!PKCE.isValidVerifier(String(repeating: "a", count: 42)))   // < 43
+        #expect(!PKCE.isValidVerifier(String(repeating: "a", count: 129)))  // > 128
+        #expect(!PKCE.isValidVerifier(String(repeating: "a", count: 42) + " "))  // space not unreserved
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/RequestAndRedactionTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/RequestAndRedactionTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+@Suite struct HTTPRequestTests {
+    @Test func formPOSTSetsContentTypeAndSortedBody() {
+        let url = URL(string: "https://example.com/token")!
+        let request = HTTPRequest.formPOST(url: url, fields: ["b": "2", "a": "1"])
+        #expect(request.method == .POST)
+        #expect(request.headers["Content-Type"] == "application/x-www-form-urlencoded")
+        #expect(String(decoding: request.body ?? Data(), as: UTF8.self) == "a=1&b=2")
+    }
+
+    @Test func formEncodingPercentEscapesAndSortsKeys() {
+        let encoded = FormURLEncoding.encode([
+            "redirect_uri": "http://127.0.0.1:8080/callback",
+            "code": "a b",
+        ])
+        #expect(encoded == "code=a%20b&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fcallback")
+    }
+
+    @Test func redactedDescriptionMasksAuthorization() {
+        let url = URL(string: "https://api.github.com/user")!
+        let request = HTTPRequest(method: .GET, url: url, headers: [
+            "Authorization": "Bearer SUPERSECRET",
+            "Accept": "application/json",
+        ])
+        let description = request.redactedDescription
+        #expect(!description.contains("SUPERSECRET"))
+        #expect(description.contains(Redaction.placeholder))
+        #expect(description.contains("application/json"))
+    }
+}
+
+@Suite struct RedactionTests {
+    @Test func redactHeadersMasksSensitiveOnly() {
+        let redacted = Redaction.redactHeaders([
+            "Authorization": "Bearer x",
+            "Cookie": "s=1",
+            "Accept": "application/json",
+        ])
+        #expect(redacted["Authorization"] == Redaction.placeholder)
+        #expect(redacted["Cookie"] == Redaction.placeholder)
+        #expect(redacted["Accept"] == "application/json")
+    }
+
+    @Test func redactTokenDefaultAndPrefixHint() {
+        #expect(Redaction.redactToken("supersecret") == Redaction.placeholder)
+        let hinted = Redaction.redactToken("supersecret", keepingPrefix: 4)
+        #expect(hinted.hasPrefix("supe"))
+        #expect(!hinted.contains("secret"))
+    }
+
+    @Test func redactTokenJSONMasksTokenValues() {
+        let body = #"{"access_token":"AAA","refresh_token":"BBB","token_type":"bearer"}"#
+        let redacted = Redaction.redactTokenJSON(body)
+        #expect(!redacted.contains("AAA"))
+        #expect(!redacted.contains("BBB"))
+        #expect(redacted.contains("bearer"))
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/RevocationTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/RevocationTests.swift
@@ -1,0 +1,142 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+// A transport that records the request it was handed and returns a fixed status.
+private actor RevokeFakeTransport: OAuthTransport {
+    let status: Int
+    private(set) var sent: HTTPRequest?
+    init(status: Int) { self.status = status }
+    func send(_ request: HTTPRequest) async throws -> OAuthHTTPResponse {
+        sent = request
+        return OAuthHTTPResponse(status: status)
+    }
+    func recorded() -> HTTPRequest? { sent }
+}
+
+// A provider that does NOT support revocation, to exercise the unavailable path.
+private struct NonRevocableProvider: OAuthProvider {
+    let id = "stub"
+    let usesPKCE = false
+    private let url = URL(string: "https://example.com")!
+    func authorizeURL(state: String, codeChallenge: String?, redirectURI: URL) -> URL { url }
+    func tokenRequest(code: String, codeVerifier: String?, redirectURI: URL) -> HTTPRequest { HTTPRequest(method: .POST, url: url) }
+    func refreshRequest(refreshToken: String) -> HTTPRequest { HTTPRequest(method: .POST, url: url) }
+    func identityRequest(accessToken: String) -> HTTPRequest { HTTPRequest(method: .GET, url: url) }
+    func parseToken(_ body: Data) throws -> TokenSet { throw OAuthError.malformedTokenResponse("stub") }
+    func parseIdentity(_ body: Data) throws -> Identity { throw OAuthError.malformedIdentityResponse("stub") }
+}
+
+@Suite struct TokenTypeHintTests {
+    @Test func rawValuesMatchRFC7009() {
+        #expect(TokenTypeHint.accessToken.rawValue == "access_token")
+        #expect(TokenTypeHint.refreshToken.rawValue == "refresh_token")
+    }
+}
+
+@Suite struct RevokeRequestTests {
+    private let redirect = URL(string: "http://127.0.0.1:8080/callback")!
+
+    // MARK: Discord (RFC 7009)
+
+    @Test func discordRevokeShape() throws {
+        let provider = DiscordProvider(config: .init(clientID: "CID", clientSecret: "SECRET"))
+        let request = try #require(provider.revokeRequest(token: "TOK", tokenTypeHint: .accessToken))
+        #expect(request.method == .POST)
+        #expect(request.url.absoluteString == "https://discord.com/api/oauth2/token/revoke")
+        let body = String(decoding: request.body ?? Data(), as: UTF8.self)
+        #expect(body.contains("token=TOK"))
+        #expect(body.contains("token_type_hint=access_token"))
+        #expect(body.contains("client_id=CID"))
+        #expect(body.contains("client_secret=SECRET"))
+    }
+
+    // MARK: Mastodon (RFC 7009, per-instance)
+
+    @Test func mastodonRevokeShape() throws {
+        let provider = MastodonProvider(config: .init(
+            clientID: "CID", clientSecret: "SECRET",
+            instanceBaseURL: URL(string: "https://mastodon.example")
+        ))
+        let request = try #require(provider.revokeRequest(token: "TOK", tokenTypeHint: .accessToken))
+        #expect(request.method == .POST)
+        #expect(request.url.absoluteString == "https://mastodon.example/oauth/revoke")
+        let body = String(decoding: request.body ?? Data(), as: UTF8.self)
+        #expect(body.contains("client_id=CID"))
+        #expect(body.contains("client_secret=SECRET"))
+        #expect(body.contains("token=TOK"))
+    }
+
+    @Test func mastodonRevokeNilWithoutSecret() {
+        let provider = MastodonProvider(config: .init(
+            clientID: "CID", instanceBaseURL: URL(string: "https://mastodon.example")
+        ))
+        #expect(provider.revokeRequest(token: "TOK", tokenTypeHint: .accessToken) == nil)
+    }
+
+    // MARK: GitHub (its own DELETE-based scheme)
+
+    @Test func githubRevokeShape() throws {
+        let provider = GitHubProvider(config: .init(clientID: "CID", clientSecret: "SECRET"))
+        let request = try #require(provider.revokeRequest(token: "gho_TOK", tokenTypeHint: .accessToken))
+        #expect(request.method == .DELETE)
+        #expect(request.url.absoluteString == "https://api.github.com/applications/CID/token")
+        // Basic auth decodes to "client_id:client_secret".
+        let auth = try #require(request.headers["Authorization"])
+        #expect(auth.hasPrefix("Basic "))
+        let b64 = String(auth.dropFirst("Basic ".count))
+        let decoded = String(decoding: try #require(Data(base64Encoded: b64)), as: UTF8.self)
+        #expect(decoded == "CID:SECRET")
+        let body = String(decoding: request.body ?? Data(), as: UTF8.self)
+        #expect(body.contains("access_token"))
+        #expect(body.contains("gho_TOK"))
+    }
+
+    @Test func githubRevokeNilWithoutSecret() {
+        let provider = GitHubProvider(config: .init(clientID: "CID"))
+        #expect(provider.revokeRequest(token: "TOK", tokenTypeHint: .accessToken) == nil)
+    }
+}
+
+@Suite struct OAuthClientRevokeTests {
+    private let github = GitHubProvider(config: .init(clientID: "CID", clientSecret: "SECRET"))
+
+    @Test func revokeSucceedsOn200() async throws {
+        let transport = RevokeFakeTransport(status: 200)
+        let discord = DiscordProvider(config: .init(clientID: "CID", clientSecret: "SECRET"))
+        try await OAuthClient(transport: transport).revoke(provider: discord, token: "TOK")
+        let sent = await transport.recorded()
+        #expect(sent?.url.absoluteString == "https://discord.com/api/oauth2/token/revoke")
+    }
+
+    @Test func revokeSucceedsOn204() async throws {
+        // GitHub revocation returns 204 No Content.
+        let transport = RevokeFakeTransport(status: 204)
+        try await OAuthClient(transport: transport).revoke(provider: github, token: "gho_TOK")
+        let sent = await transport.recorded()
+        #expect(sent?.method == .DELETE)
+    }
+
+    @Test func revokeThrowsOnNonSuccess() async {
+        let transport = RevokeFakeTransport(status: 401)
+        await #expect(throws: OAuthError.self) {
+            try await OAuthClient(transport: transport).revoke(provider: self.github, token: "TOK")
+        }
+    }
+
+    @Test func revokeUnavailableWhenProviderCannotBuildRequest() async {
+        // GitHub without a client secret cannot build a revoke request.
+        let noSecret = GitHubProvider(config: .init(clientID: "CID"))
+        let transport = RevokeFakeTransport(status: 200)
+        await #expect(throws: OAuthError.self) {
+            try await OAuthClient(transport: transport).revoke(provider: noSecret, token: "TOK")
+        }
+    }
+
+    @Test func revokeUnavailableForNonRevocableProvider() async {
+        let transport = RevokeFakeTransport(status: 200)
+        await #expect(throws: OAuthError.self) {
+            try await OAuthClient(transport: transport).revoke(provider: NonRevocableProvider(), token: "TOK")
+        }
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/TokenStoreTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/TokenStoreTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+@Suite struct TokenStoreTests {
+    private func tempStore() -> TokenStore {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftoauth-tests-\(UUID().uuidString)", isDirectory: true)
+        return TokenStore(directory: dir)
+    }
+
+    private func token(_ provider: String, access: String = "at") -> TokenSet {
+        TokenSet(accessToken: access, tokenType: "bearer", refreshToken: "rt",
+                 scope: "read", expiresIn: 3600, providerID: provider)
+    }
+
+    @Test func loadAllEmptyWhenNoFile() throws {
+        #expect(try tempStore().loadAll().isEmpty)
+    }
+
+    @Test func saveThenLoadRoundTrip() throws {
+        let store = tempStore()
+        let original = token("github", access: "gho_x")
+        try store.save(original)
+        #expect(try store.load(providerID: "github") == original)
+    }
+
+    @Test func multipleProvidersCoexist() throws {
+        let store = tempStore()
+        try store.save(token("github", access: "gh"))
+        try store.save(token("discord", access: "dc"))
+        #expect(try store.load(providerID: "github")?.accessToken == "gh")
+        #expect(try store.load(providerID: "discord")?.accessToken == "dc")
+        #expect(try store.loadAll().count == 2)
+    }
+
+    @Test func saveOverwritesSameProvider() throws {
+        let store = tempStore()
+        try store.save(token("github", access: "old"))
+        try store.save(token("github", access: "new"))
+        #expect(try store.load(providerID: "github")?.accessToken == "new")
+        #expect(try store.loadAll().count == 1)
+    }
+
+    @Test func deleteRemovesOnlyThatProvider() throws {
+        let store = tempStore()
+        try store.save(token("github"))
+        try store.save(token("discord"))
+        try store.delete(providerID: "github")
+        #expect(try store.load(providerID: "github") == nil)
+        #expect(try store.load(providerID: "discord") != nil)
+    }
+
+    @Test func loadMissingProviderReturnsNil() throws {
+        let store = tempStore()
+        try store.save(token("github"))
+        #expect(try store.load(providerID: "discord") == nil)
+    }
+
+    #if !os(Windows)
+    @Test func fileIsOwnerOnly0600() throws {
+        // POSIX-only: Windows relies on %USERPROFILE% ACL inheritance instead.
+        let store = tempStore()
+        try store.save(token("github"))
+        let path = store.directory.appendingPathComponent("tokens.json").path
+        let attrs = try FileManager.default.attributesOfItem(atPath: path)
+        let perms = (attrs[.posixPermissions] as? NSNumber)?.intValue
+        #expect(perms == 0o600)
+    }
+    #endif
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/ValueTypeTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthCoreTests/ValueTypeTests.swift
@@ -1,0 +1,59 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthCore
+
+@Suite struct TokenSetTests {
+    private let base = Date(timeIntervalSince1970: 1_000_000)
+
+    @Test func codableRoundTrip() throws {
+        let token = TokenSet(
+            accessToken: "at", tokenType: "bearer", refreshToken: "rt",
+            scope: "read", expiresIn: 3600, obtainedAt: base, providerID: "github"
+        )
+        let data = try JSONEncoder().encode(token)
+        #expect(try JSONDecoder().decode(TokenSet.self, from: data) == token)
+    }
+
+    @Test func expiresAtIsObtainedPlusExpiresIn() {
+        let token = TokenSet(accessToken: "x", tokenType: "bearer",
+                             expiresIn: 3600, obtainedAt: base, providerID: "github")
+        #expect(token.expiresAt == base.addingTimeInterval(3600))
+    }
+
+    @Test func isExpiredAcrossLifetime() {
+        let token = TokenSet(accessToken: "x", tokenType: "bearer",
+                             expiresIn: 3600, obtainedAt: base, providerID: "github")
+        #expect(!token.isExpired(now: base))                              // fresh
+        #expect(token.isExpired(now: base.addingTimeInterval(3600)))      // at expiry
+        #expect(token.isExpired(now: base.addingTimeInterval(4000)))      // past expiry
+    }
+
+    @Test func nonExpiringWhenNoExpiresIn() {
+        let token = TokenSet(accessToken: "x", tokenType: "bearer", providerID: "github")
+        #expect(token.expiresAt == nil)
+        #expect(!token.isExpired(now: Date(timeIntervalSince1970: 9_999_999_999)))
+    }
+
+    @Test func bearerAuthorizationHeader() {
+        let token = TokenSet(accessToken: "SECRET", tokenType: "bearer", providerID: "github")
+        #expect(token.authorizationHeader == "Bearer SECRET")
+    }
+
+    @Test func descriptionRedactsSecrets() {
+        let token = TokenSet(accessToken: "SUPERSECRETACCESS", tokenType: "bearer",
+                             refreshToken: "SUPERSECRETREFRESH", providerID: "github")
+        let description = token.description
+        #expect(!description.contains("SUPERSECRETACCESS"))
+        #expect(!description.contains("SUPERSECRETREFRESH"))
+        #expect(description.contains("github"))
+    }
+}
+
+@Suite struct IdentityTests {
+    @Test func codableRoundTrip() throws {
+        let identity = Identity(providerID: "github", id: "42", username: "octocat",
+                                displayName: "The Octocat", raw: ["type": "User"])
+        let data = try JSONEncoder().encode(identity)
+        #expect(try JSONDecoder().decode(Identity.self, from: data) == identity)
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthServerTests/CallbackClassifyTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthServerTests/CallbackClassifyTests.swift
@@ -1,0 +1,72 @@
+import Testing
+import Foundation
+@testable import SwiftOAuthServer
+import SwiftOAuthCore
+
+@Suite struct CallbackClassifyTests {
+    private func q(_ pairs: [(String, String)]) -> [(key: Substring, value: Substring)] {
+        pairs.map { (key: Substring($0.0), value: Substring($0.1)) }
+    }
+
+    @Test func validCodeWithMatchingState() {
+        let outcome = CallbackServer.classify(
+            query: q([("state", "STATE123"), ("code", "THECODE")]),
+            expectedState: "STATE123"
+        )
+        #expect(outcome == .code("THECODE"))
+    }
+
+    @Test func stateMismatchRejectedBeforeCode() {
+        // Even with a valid code present, a wrong state must be rejected.
+        let outcome = CallbackServer.classify(
+            query: q([("state", "WRONG"), ("code", "THECODE")]),
+            expectedState: "STATE123"
+        )
+        #expect(outcome == .stateMismatch)
+    }
+
+    @Test func missingStateRejected() {
+        let outcome = CallbackServer.classify(
+            query: q([("code", "THECODE")]),
+            expectedState: "STATE123"
+        )
+        #expect(outcome == .stateMismatch)
+    }
+
+    @Test func providerErrorSurfaced() {
+        let outcome = CallbackServer.classify(
+            query: q([("state", "S"), ("error", "access_denied"), ("error_description", "User denied")]),
+            expectedState: "S"
+        )
+        #expect(outcome == .providerError(error: "access_denied", description: "User denied"))
+    }
+
+    @Test func emptyCodeIsMissingParameters() {
+        let outcome = CallbackServer.classify(
+            query: q([("state", "S"), ("code", "")]),
+            expectedState: "S"
+        )
+        #expect(outcome == .missingParameters)
+    }
+
+    @Test func noCodeNoErrorIsMissingParameters() {
+        let outcome = CallbackServer.classify(
+            query: q([("state", "S")]),
+            expectedState: "S"
+        )
+        #expect(outcome == .missingParameters)
+    }
+}
+
+@Suite struct CallbackServerConfigTests {
+    @Test func redirectURIBindsLoopbackIP() {
+        // RFC 8252: must be the literal 127.0.0.1, not "localhost".
+        let config = CallbackServerConfig(expectedState: "x")
+        #expect(config.redirectURI(boundPort: 8080).absoluteString == "http://127.0.0.1:8080/callback")
+    }
+
+    @Test func customPathHonoured() {
+        let config = CallbackServerConfig(path: "/cb", expectedState: "x")
+        #expect(config.redirectURI(boundPort: 9000).absoluteString == "http://127.0.0.1:9000/cb")
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthServerTests/CallbackServerIntegrationTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthServerTests/CallbackServerIntegrationTests.swift
@@ -1,0 +1,112 @@
+import Testing
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import SwiftOAuthServer
+import SwiftOAuthCore
+
+/// End-to-end loopback tests: a real Hummingbird server binds an ephemeral
+/// 127.0.0.1 port, we drive the browser-redirect step with a plain HTTP GET
+/// against that port, and assert the captured outcome. No external OAuth
+/// provider is contacted — the "authorize" half is simulated by hitting the
+/// callback URL the way a provider's 302 would.
+@Suite struct CallbackServerIntegrationTests {
+
+    /// Perform a GET and return (status, body) — cross-platform.
+    private func get(_ url: URL) async throws -> (Int, String) {
+        let (data, response) = try await URLSession.shared.data(from: url)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        return (status, String(decoding: data, as: UTF8.self))
+    }
+
+    /// Probe a URL with a short timeout. Used to assert the server has stopped
+    /// answering after shutdown; on Windows a refused loopback connection can
+    /// otherwise sit on `URLSession`'s default 60s timeout, so cap it tightly.
+    private func probe(_ url: URL) async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 3
+        configuration.timeoutIntervalForResource = 3
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+        _ = try await session.data(from: url)
+    }
+
+    /// Build the callback URL a provider would redirect to for a bound server.
+    private func callbackURL(_ redirectURI: URL, query: String) -> URL {
+        URL(string: redirectURI.absoluteString + "?" + query)!
+    }
+
+    @Test func happyPathCaptureCodeAndShutdown() async throws {
+        let state = OAuthState.generate().value
+        let server = CallbackServer(config: .init(expectedState: state))
+
+        let result = try await server.run { redirectURI in
+            // Simulate the provider's redirect back to the loopback server.
+            let url = self.callbackURL(redirectURI, query: "code=GOODCODE&state=\(state)")
+            _ = try? await self.get(url)
+        }
+
+        #expect(result.outcome == .code("GOODCODE"))
+        #expect(result.boundPort > 0)
+        #expect(result.redirectURI.absoluteString.hasPrefix("http://127.0.0.1:"))
+
+        // The server must have shut down — the port should no longer answer.
+        let probeURL = self.callbackURL(result.redirectURI, query: "code=x&state=\(state)")
+        do {
+            try await self.probe(probeURL)
+            Issue.record("server still answering after one-shot shutdown")
+        } catch {
+            // expected: connection refused (or a fast timeout)
+        }
+    }
+
+    @Test func returnedSuccessPageToBrowser() async throws {
+        let state = OAuthState.generate().value
+        let server = CallbackServer(config: .init(expectedState: state))
+
+        // Capture the HTTP response the "browser" receives via onBound.
+        let captured = ResponseBox()
+        let result = try await server.run { redirectURI in
+            let url = self.callbackURL(redirectURI, query: "code=OK&state=\(state)")
+            if let pair = try? await self.get(url) { await captured.set(pair) }
+        }
+
+        #expect(result.outcome == .code("OK"))
+        let page = await captured.value
+        #expect(page?.0 == 200)
+        #expect(page?.1.contains("You may close this tab") == true)
+    }
+
+    @Test func stateMismatchIsRejectedEndToEnd() async throws {
+        let state = OAuthState.generate().value
+        let server = CallbackServer(config: .init(expectedState: state))
+
+        let result = try await server.run { redirectURI in
+            // Wrong state — simulates a CSRF / forged callback.
+            let url = self.callbackURL(redirectURI, query: "code=GOODCODE&state=TAMPERED")
+            _ = try? await self.get(url)
+        }
+
+        #expect(result.outcome == .stateMismatch)
+    }
+
+    @Test func providerErrorIsSurfacedEndToEnd() async throws {
+        let state = OAuthState.generate().value
+        let server = CallbackServer(config: .init(expectedState: state))
+
+        let result = try await server.run { redirectURI in
+            let url = self.callbackURL(redirectURI, query: "error=access_denied&state=\(state)")
+            _ = try? await self.get(url)
+        }
+
+        #expect(result.outcome == .providerError(error: "access_denied", description: nil))
+    }
+
+    /// Small actor box to ferry the captured browser response out of the
+    /// `onBound` closure.
+    private actor ResponseBox {
+        private(set) var value: (Int, String)?
+        func set(_ v: (Int, String)) { value = v }
+    }
+}

--- a/source/ios-swift-swiftoauth/Tests/SwiftOAuthServerTests/LoginLoopIntegrationTests.swift
+++ b/source/ios-swift-swiftoauth/Tests/SwiftOAuthServerTests/LoginLoopIntegrationTests.swift
@@ -1,0 +1,75 @@
+import Testing
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import SwiftOAuthServer
+import SwiftOAuthCore
+
+/// Fake transport returning a recorded provider token body — no network.
+private actor FakeTransport: OAuthTransport {
+    private let response: OAuthHTTPResponse
+    init(status: Int, body: String) {
+        self.response = OAuthHTTPResponse(status: status, body: Data(body.utf8))
+    }
+    func send(_ request: HTTPRequest) async throws -> OAuthHTTPResponse { response }
+}
+
+/// Exercises the exact composition the CLI `login` command performs — loopback
+/// callback capture → code → token exchange → token store — but with a fake
+/// transport instead of a real provider, and a temp token store. The browser
+/// step and AsyncHTTPClient are the only pieces not covered here (they shell out
+/// / open a socket and are intentionally left to manual/integration use).
+@Suite struct LoginLoopIntegrationTests {
+
+    private func get(_ url: URL) async {
+        _ = try? await URLSession.shared.data(from: url)
+    }
+
+    @Test func fullAuthorizeToStoredTokenLoop() async throws {
+        let provider = GitHubProvider(config: .init(clientID: "CID", clientSecret: "SECRET"))
+        let state = OAuthState.generate()
+        let server = CallbackServer(config: .init(expectedState: state.value))
+
+        // 1. Capture the callback (simulated provider redirect).
+        let result = try await server.run { redirectURI in
+            let url = URL(string: redirectURI.absoluteString + "?code=GOODCODE&state=\(state.value)")!
+            await self.get(url)
+        }
+        guard case .code(let code) = result.outcome else {
+            Issue.record("expected a code outcome, got \(result.outcome)")
+            return
+        }
+
+        // 2. Exchange the code via the fake transport.
+        let oauthClient = OAuthClient(transport: FakeTransport(
+            status: 200,
+            body: #"{"access_token":"gho_LOOP","token_type":"bearer","scope":"read:user"}"#
+        ))
+        let token = try await oauthClient.exchangeAuthorizationCode(
+            provider: provider, code: code, codeVerifier: nil, redirectURI: result.redirectURI
+        )
+
+        // 3. Persist and read back from a temp store.
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("swiftoauth-loop-\(UUID().uuidString)", isDirectory: true)
+        let store = TokenStore(directory: dir)
+        try store.save(token)
+
+        let loaded = try store.load(providerID: "github")
+        #expect(loaded?.accessToken == "gho_LOOP")
+        #expect(loaded?.providerID == "github")
+    }
+
+    @Test func tamperedStateNeverReachesExchange() async throws {
+        let state = OAuthState.generate()
+        let server = CallbackServer(config: .init(expectedState: state.value))
+
+        let result = try await server.run { redirectURI in
+            let url = URL(string: redirectURI.absoluteString + "?code=GOODCODE&state=FORGED")!
+            await self.get(url)
+        }
+        // A CSRF-tampered callback must surface as a mismatch, not a code.
+        #expect(result.outcome == .stateMismatch)
+    }
+}

--- a/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/Package.swift
+++ b/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/Package.swift
@@ -1,0 +1,52 @@
+// swift-tools-version:6.0
+// adaptivecards-swiftoauth-demo
+// Runtime symbol-check example for the vendored swiftoauth kit.
+// Inherits the repo-root MIT license.
+
+import PackageDescription
+
+let package = Package(
+    name: "adaptivecards-swiftoauth-demo",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v14),
+        .tvOS(.v17),
+        .watchOS(.v10),
+        .visionOS(.v1),
+    ],
+    products: [
+        .executable(name: "AdaptiveCardsDemo", targets: ["AdaptiveCardsDemo"]),
+    ],
+    dependencies: [
+        // Path-dep on the vendored swiftoauth snapshot one folder up.
+        .package(path: "../.."),
+
+        // SwiftPM's fork-over-upstream identity override only takes effect from
+        // the ROOT package being built. Here the ROOT is this demo, which only
+        // path-deps the kit; the kit's Hummingbird transitively pulls
+        // apple/swift-nio, which fails to compile on Windows. Re-declaring the
+        // public hggz Windows-supported forks here (same revisions the kit
+        // pins) makes this demo's resolution authoritative so the forks win.
+        // They are public HTTPS remotes (no SSH URLs) and carry no target
+        // dependency — declaring them is enough to steer identity resolution.
+        .package(url: "https://github.com/hggz/hummingbird.git",
+                 revision: "3e8921437eb791e06662d9f8cbfcd55f18c4759a"),
+        .package(url: "https://github.com/hggz/swift-nio.git",
+                 revision: "7c9c6861c968f8902c0610ab4ba2e23311f5092c"),
+        .package(url: "https://github.com/hggz/swift-nio-extras.git",
+                 revision: "076c9b493c6fe365ba42663fc16c4239d17dfb92"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "AdaptiveCardsDemo",
+            dependencies: [
+                // SwiftPM identifies a `path:` dependency by the folder
+                // basename ("ios-swift-swiftoauth") rather than the manifest's
+                // `name:` ("swiftoauth"), so reference the package by its
+                // on-disk folder name here.
+                .product(name: "SwiftOAuthCore", package: "ios-swift-swiftoauth"),
+                .product(name: "SwiftOAuthServer", package: "ios-swift-swiftoauth"),
+            ]
+        ),
+    ]
+)

--- a/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/README.md
+++ b/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/README.md
@@ -1,0 +1,75 @@
+# adaptivecards-swiftoauth-demo
+
+Runtime symbol-check example for the vendored `swiftoauth` kit, as
+required by the proxy-integration ADDENDUM v2 §13.
+
+## What it proves
+
+`swift build -c debug` succeeding only proves the manifest parses and
+the compiler links. This example additionally proves the vendored kit's
+public Swift surface area still works end-to-end against a real
+AdaptiveCard JSON payload, on Windows MSVC.
+
+The demo follows the **Flavor B ("transport / HTTP")** template from the
+addendum:
+
+1. Loads the canonical "Hello World" Adaptive Card sample
+   ([adaptivecards.io/samples](https://adaptivecards.io/samples/)),
+   verbatim, and parses it with Foundation `JSONDecoder`, deriving the
+   fact `body[0].type` (== `"TextBlock"`).
+2. Generates a CSRF `state` (`SwiftOAuthCore.OAuthState`) and a PKCE
+   pair (`SwiftOAuthCore.PKCE`), asserting the pair is RFC 7636-valid.
+3. Binds `SwiftOAuthServer.CallbackServer` — the kit's loopback OAuth
+   callback server — on the literal `127.0.0.1` (RFC 8252 §7.3) at an
+   OS-assigned ephemeral port.
+4. From the server's `onBound` hook, issues a real loopback HTTP request
+   to the bound URL carrying the derived card fact as the OAuth `code`
+   alongside the `state` — the exact shape a provider's browser redirect
+   takes (RFC 6749 §4.1.2).
+5. The server validates the `state` with a constant-time CSRF check and
+   captures the code; the demo asserts the captured code equals the
+   derived card fact (`"TextBlock"`) and that the server bound a
+   `127.0.0.1` loopback address.
+
+If all steps pass, the program prints
+`PASS adaptivecards-swiftoauth-http` and exits 0.  
+Any deviation prints `FAIL adaptivecards-swiftoauth-... : <reason>` and
+exits 1, which fails the CI gate.
+
+> Note: the kit's loopback server answers `GET /callback` (the OAuth
+> redirect shape), so the card fact is round-tripped over a real
+> loopback HTTP GET rather than a POST body. This exercises the kit's
+> genuine HTTP-server surface instead of fabricating an endpoint the kit
+> does not ship.
+
+## Symbols exercised
+
+The demo touches the following public symbols from the vendored
+`swiftoauth` kit. CI logs this list verbatim so reviewers can see the
+surface area the demo actually covers (well over the addendum's "≥3
+distinct symbols" minimum).
+
+- `SwiftOAuthCore.OAuthState` (`generate()`, `.value`, `.matches(_:)`)
+- `SwiftOAuthCore.PKCE` (`generate()`, `.codeVerifier`, `.codeChallenge`,
+  `isValidVerifier(_:)`, `challenge(for:)`)
+- `SwiftOAuthServer.CallbackServerConfig` (`init(expectedState:)`,
+  `redirectURI(boundPort:)`)
+- `SwiftOAuthServer.CallbackServer` (`init(config:)`, `run(onBound:)`)
+- `SwiftOAuthServer.CallbackServer.RunResult` (`.outcome`, `.boundPort`,
+  `.redirectURI`)
+- `SwiftOAuthServer.CallbackOutcome` (`.code` case)
+
+## Running
+
+```pwsh
+./smoke.ps1            # Windows
+```
+
+```bash
+./smoke.sh             # macOS / Linux
+```
+
+This drop does not need zlib (the loopback server uses Hummingbird's
+HTTP/1 runtime, not nio-ssl/compression). The `-ZlibInc`/`-ZlibLib`
+parameters on `smoke.ps1` are accepted for template compatibility and
+are no-ops here.

--- a/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/Sources/AdaptiveCardsDemo/SampleCard.swift
+++ b/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/Sources/AdaptiveCardsDemo/SampleCard.swift
@@ -1,0 +1,27 @@
+// SampleCard.swift
+// Canonical "Hello World" Adaptive Card payload as published on
+// https://adaptivecards.io/samples/ . Embedded verbatim so the
+// runtime symbol-check exercises a real AdaptiveCard JSON shape, not
+// a synthesized one.
+
+import Foundation
+
+enum SampleCard {
+    /// The minimal "Hello World" Adaptive Card from adaptivecards.io,
+    /// schema 1.5. Foundation `JSONDecoder` parses this and the demo
+    /// derives `body[0].type` (== "TextBlock") as the fact carried over
+    /// the loopback OAuth round-trip.
+    static let helloWorldJSON: String = """
+    {
+        "type": "AdaptiveCard",
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "version": "1.5",
+        "body": [
+            {
+                "type": "TextBlock",
+                "text": "Hello, World!"
+            }
+        ]
+    }
+    """
+}

--- a/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/Sources/AdaptiveCardsDemo/main.swift
+++ b/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/Sources/AdaptiveCardsDemo/main.swift
@@ -1,0 +1,134 @@
+// main.swift
+// Flavor B ("transport / HTTP") symbol-check demo.
+//
+// Binds the vendored swiftoauth loopback server (SwiftOAuthServer's
+// CallbackServer) on 127.0.0.1, then drives one real loopback HTTP
+// round-trip that carries a fact derived from the canonical
+// "Hello World" Adaptive Card.
+//
+// Steps:
+//   1. Parse the canonical adaptivecards.io card with Foundation
+//      JSONDecoder and derive the fact `body[0].type` (== "TextBlock").
+//   2. Generate a CSRF `state` (SwiftOAuthCore.OAuthState) and a PKCE
+//      pair (SwiftOAuthCore.PKCE); assert the PKCE pair is RFC 7636-valid.
+//   3. Bind SwiftOAuthServer.CallbackServer on 127.0.0.1:<ephemeral>.
+//   4. From the `onBound` hook, issue a real HTTP GET to the bound
+//      loopback URL carrying the derived card fact as the OAuth `code`
+//      together with the `state` — exactly the shape a provider's
+//      browser redirect takes (RFC 6749 §4.1.2 / RFC 8252 §7.3).
+//   5. The server validates `state` exactly (constant-time CSRF check)
+//      and captures the code; assert the captured code == the derived
+//      card fact == "TextBlock".
+//   6. Print `PASS adaptivecards-swiftoauth-http` and exit 0; any
+//      deviation prints `FAIL ...` and exits 1.
+//
+// Symbols exercised (cross-referenced in README.md):
+//   - SwiftOAuthCore.OAuthState  (generate, .value, .matches)
+//   - SwiftOAuthCore.PKCE        (generate, .codeVerifier, .codeChallenge,
+//                                 isValidVerifier, challenge(for:))
+//   - SwiftOAuthServer.CallbackServerConfig  (init, redirectURI(boundPort:))
+//   - SwiftOAuthServer.CallbackServer        (init(config:), run(onBound:))
+//   - SwiftOAuthServer.CallbackServer.RunResult (.outcome, .boundPort, .redirectURI)
+//   - SwiftOAuthServer.CallbackOutcome       (.code case)
+
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import SwiftOAuthCore
+import SwiftOAuthServer
+
+// A `main.swift` file is the executable entry point, so drive the demo
+// inline with top-level `await` (no `@main`).
+do {
+    try await runDemo()
+    print("PASS adaptivecards-swiftoauth-http")
+    exit(0)
+} catch {
+    print("FAIL adaptivecards-swiftoauth-http: \(error)")
+    exit(1)
+}
+
+enum DemoError: Error, CustomStringConvertible {
+    case malformedSample
+    case unexpectedOutcome(String)
+    case factMismatch(expected: String, got: String)
+
+    var description: String {
+        switch self {
+        case .malformedSample:
+            return "canonical sample card did not decode as expected"
+        case .unexpectedOutcome(let o):
+            return "loopback server returned an unexpected outcome: \(o)"
+        case .factMismatch(let expected, let got):
+            return "round-tripped fact mismatch: expected \(expected), got \(got)"
+        }
+    }
+}
+
+// Minimal Codable shape for the canonical Adaptive Card. Foundation
+// JSONDecoder parses the card; we only need `type` and `body[].type`.
+private struct AdaptiveCard: Decodable {
+    let type: String
+    let body: [Element]
+    struct Element: Decodable { let type: String }
+}
+
+func runDemo() async throws {
+    // 1) Parse the canonical sample card and derive `body[0].type`.
+    let cardData = Data(SampleCard.helloWorldJSON.utf8)
+    let card = try JSONDecoder().decode(AdaptiveCard.self, from: cardData)
+    guard card.type == "AdaptiveCard", let firstElement = card.body.first else {
+        throw DemoError.malformedSample
+    }
+    let cardFact = firstElement.type           // "TextBlock"
+    print("derived card fact body[0].type = \(cardFact)")
+
+    // 2) Generate the CSRF state + PKCE pair from the kit's core API.
+    let state = OAuthState.generate()
+    let pkce = PKCE.generate()
+    guard PKCE.isValidVerifier(pkce.codeVerifier),
+          PKCE.challenge(for: pkce.codeVerifier) == pkce.codeChallenge else {
+        throw DemoError.malformedSample
+    }
+    print("state (\(state.value.count) chars) + PKCE S256 challenge (\(pkce.codeChallenge.count) chars) generated")
+
+    // 3) Bind the loopback callback server on 127.0.0.1 (ephemeral port).
+    let server = CallbackServer(config: .init(expectedState: state.value))
+
+    // 4+5) Drive one real loopback HTTP round-trip from `onBound`: the
+    //      derived card fact rides back as the OAuth `code`, guarded by the
+    //      `state`. The server validates `state` and captures the code.
+    let result = try await server.run { redirectURI in
+        let callback = redirectURI.absoluteString
+            + "?code=\(cardFact)&state=\(state.value)"
+        guard let url = URL(string: callback) else { return }
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        _ = try? await URLSession.shared.data(for: request)
+    }
+
+    print("server bound 127.0.0.1:\(result.boundPort), redirect_uri = \(result.redirectURI.absoluteString)")
+    guard result.redirectURI.absoluteString.hasPrefix("http://127.0.0.1:") else {
+        throw DemoError.unexpectedOutcome("redirect_uri not loopback: \(result.redirectURI)")
+    }
+
+    // 6) Assert the captured code == the card fact carried over the wire.
+    switch result.outcome {
+    case .code(let captured):
+        guard captured == cardFact else {
+            throw DemoError.factMismatch(expected: cardFact, got: captured)
+        }
+        // Sanity: the CSRF state we generated matches what the server validated.
+        guard state.matches(state.value) else {
+            throw DemoError.unexpectedOutcome("state self-check failed")
+        }
+        print("loopback round-trip captured code == card fact (\(captured)) with state validated")
+    case .stateMismatch:
+        throw DemoError.unexpectedOutcome("stateMismatch (CSRF check rejected the callback)")
+    case .providerError(let error, let description):
+        throw DemoError.unexpectedOutcome("providerError \(error) \(description ?? "")")
+    case .missingParameters:
+        throw DemoError.unexpectedOutcome("missingParameters")
+    }
+}

--- a/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/smoke.ps1
+++ b/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/smoke.ps1
@@ -1,0 +1,96 @@
+#!/usr/bin/env pwsh
+# smoke.ps1 — Windows MSVC runtime symbol-check.
+#
+# Builds the adaptivecards-swiftoauth-demo executable against the
+# vendored swiftoauth kit, runs it, and asserts the success line.
+# Exit non-zero on any failure.
+#
+# This drop (SwiftOAuthCore + SwiftOAuthServer, loopback callback server
+# only) does NOT need zlib: Hummingbird's HTTP/1 runtime pulls swift-nio
+# + swift-nio-extras but not nio-ssl/compression. The optional
+# -ZlibInc/-ZlibLib parameters are accepted for template compatibility
+# and threaded through only if a caller supplies them.
+#
+# On Windows the demo builds into a SHORT scratch path. Hummingbird
+# pulls swift-async-algorithms, whose deeply-nested file names (e.g.
+# MultiProducerSingleConsumerAsyncChannel+Internal.swift) overflow the
+# 260-char MAX_PATH limit when combined with this example's already-deep
+# location, breaking llbuild. A short -ScratchPath keeps every input
+# path under the limit.
+
+[CmdletBinding()]
+param(
+    [string]$ZlibInc = '',
+    [string]$ZlibLib = '',
+    [string]$ScratchPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+$here = $PSScriptRoot
+Set-Location $here
+
+$extra = @()
+if ($ZlibInc) {
+    $extra += @('-Xcc', "-I$ZlibInc", '-Xswiftc', "-I$ZlibInc")
+}
+if ($ZlibLib) {
+    $extra += @('-Xlinker', "/LIBPATH:$ZlibLib")
+}
+
+# Default to a short scratch path on Windows to dodge MAX_PATH. It MUST live on
+# the same drive as this package: `swift run` computes the executable's path
+# relative to the package dir, and a cross-drive relative path (e.g. package on
+# D:, scratch on C:) cannot be formed — it mangles into a bogus
+# `..\..\C:\...` and fails with "No such file or directory". So derive the
+# drive from this script's own location.
+if (-not $ScratchPath -and $IsWindows) {
+    $drive = (Get-Item $here).PSDrive.Name
+    $ScratchPath = "${drive}:\b\sao"
+}
+if ($ScratchPath) {
+    $extra += @('--scratch-path', $ScratchPath)
+    New-Item -ItemType Directory -Force -Path $ScratchPath | Out-Null
+    Write-Host "scratch-path: $ScratchPath"
+}
+
+Write-Host '=== swift build -c debug ===' -ForegroundColor Cyan
+& swift build -c debug @extra
+if ($LASTEXITCODE -ne 0) {
+    Write-Host 'FAIL adaptivecards-swiftoauth-build' -ForegroundColor Red
+    exit 1
+}
+
+Write-Host ''
+Write-Host '=== run AdaptiveCardsDemo ===' -ForegroundColor Cyan
+# Execute the built binary DIRECTLY rather than via `swift run`. `swift run`
+# re-derives a (possibly cross-drive) relative path to the executable and can
+# fail to launch it on the runner; running the produced .exe avoids that
+# entirely. Locate it under the scratch/build dir.
+$buildDir = if ($ScratchPath) { $ScratchPath } else { Join-Path $here '.build' }
+$exe = Get-ChildItem -Path $buildDir -Recurse -Filter 'AdaptiveCardsDemo.exe' -ErrorAction SilentlyContinue |
+    Select-Object -First 1 -ExpandProperty FullName
+if (-not $exe) {
+    # POSIX / non-.exe fallback.
+    $exe = Get-ChildItem -Path $buildDir -Recurse -Filter 'AdaptiveCardsDemo' -ErrorAction SilentlyContinue |
+        Where-Object { -not $_.PSIsContainer } | Select-Object -First 1 -ExpandProperty FullName
+}
+if (-not $exe) {
+    Write-Host 'FAIL adaptivecards-swiftoauth-run (executable not found)' -ForegroundColor Red
+    exit 1
+}
+Write-Host "exe: $exe"
+$output = & $exe 2>&1 | Out-String
+Write-Host $output
+
+if ($LASTEXITCODE -ne 0) {
+    Write-Host 'FAIL adaptivecards-swiftoauth-run (non-zero exit)' -ForegroundColor Red
+    exit 1
+}
+
+if ($output -notmatch 'PASS adaptivecards-swiftoauth-http') {
+    Write-Host 'FAIL adaptivecards-swiftoauth-assertion (PASS line not found)' -ForegroundColor Red
+    exit 1
+}
+
+Write-Host 'smoke OK' -ForegroundColor Green
+exit 0

--- a/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/smoke.sh
+++ b/source/ios-swift-swiftoauth/examples/adaptivecards-swiftoauth-demo/smoke.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# smoke.sh — POSIX runtime symbol-check.
+#
+# Builds the adaptivecards-swiftoauth-demo executable against the
+# vendored swiftoauth kit, runs it, and asserts the success line. Exit
+# non-zero on any failure.
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+echo "=== swift build -c debug ==="
+swift build -c debug
+
+echo
+echo "=== swift run AdaptiveCardsDemo ==="
+output="$(swift run -c debug AdaptiveCardsDemo 2>&1)"
+echo "$output"
+
+if ! grep -q 'PASS adaptivecards-swiftoauth-http' <<<"$output"; then
+    echo "FAIL adaptivecards-swiftoauth-assertion (PASS line not found)" >&2
+    exit 1
+fi
+
+echo "smoke OK"


### PR DESCRIPTION
Proxy-only feature branch. Not for upstream.

Adds `source/ios-swift-swiftoauth/` — a vendored snapshot of the swiftoauth Swift-on-Windows OAuth 2.0 playground (PKCE authorization-code flows + a 127.0.0.1 loopback callback server) as an experimental parallel surface alongside the production ObjC/Java/C++ Adaptive Cards stack. No edits to existing shipping code.

**Compliance:** vendored 2026-06-17, inherits repo-root MIT (no nested LICENSE, no GPL/SPDX headers); no `git@` SSH URLs in any committed Package.swift (public hggz forks only); no Apple-only imports (Foundation/Crypto/Hummingbird/NIOCore only); all LF; subfolder ~0.13 MiB. No zlib needed (loopback server uses Hummingbird HTTP/1, not nio-ssl/compression).

**Runtime symbol-check (ADDENDUM-v2 §13, Flavor B / transport):** `examples/adaptivecards-swiftoauth-demo/` binds `SwiftOAuthServer.CallbackServer` on 127.0.0.1, parses the canonical adaptivecards.io Hello-World card with Foundation JSONDecoder, and round-trips the derived `body[0].type` fact through a real loopback HTTP exchange validated by the kit's constant-time CSRF `state` check. Exercises `OAuthState`, `PKCE`, `CallbackServerConfig`, `CallbackServer`, `CallbackServer.RunResult`, and `CallbackOutcome`, then prints `PASS adaptivecards-swiftoauth-http`.

**CI:** `.github/workflows/swift-swiftoauth-bridge-gate.yml` (proxy-only, paths-scoped). Windows MSVC: NTFS-safe manual checkout, Swift 6.3.1, `swift build -c debug` (kit) + the smoke demo which must emit the PASS line. No continue-on-error.

PR target = hggzm:proxy/integration. Not for microsoft/* or hggzm:main.