### PR TITLE
fix(ios): use tooltip as the accessible name for untitled action buttons

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRButton.mm
@@ -255,7 +255,15 @@ NSString * const DYNAMIC_VISIBLE_PROP = @"isVisible.dynamic";
     [button.titleLabel setFont:[UIFont systemFontOfSize:15.0]];
     button.titleLabel.font = [UIFontMetrics.defaultMetrics scaledFontForFont:button.titleLabel.font];
     button.isAccessibilityElement = YES;
-    button.accessibilityLabel = title;
+    // When an action has no title (e.g. a Submit with only a tooltip), fall back to
+    // the tooltip so VoiceOver can name and reach the button. Without this an
+    // untitled button has an empty accessibilityLabel and is effectively
+    // unreachable / unannounced.
+    if (title.length) {
+        button.accessibilityLabel = title;
+    } else if (acoAction.tooltip.length) {
+        button.accessibilityLabel = acoAction.tooltip;
+    }
     button.enabled = [acoAction isEnabled];
     
     // Handle dynamic properties if expression evaluation is enabled


### PR DESCRIPTION
> **[PROXY-LANE DRAFT]** Staging PR on the `hggzm` fork (base `proxy/integration`) to validate the fix + evidence **before** graduating a clean single-file PR to `microsoft/Teams-AdaptiveCards-Mobile`. Not for merge here.

## Scenario (Sev1)
An `Action.Submit`/`OpenUrl` with **no `title` but a `tooltip`** rendered a button with an **empty `accessibilityLabel`**. VoiceOver could not name or reliably reach it. On the Tooltip test card the controls **collapsed into a single unnamed aggregated element**.

## Root cause
`ACRButton` set `button.accessibilityLabel = title` unconditionally; when `title` is empty the button has no accessible name and is effectively unreachable.

## Fix (`ACRButton.mm`, +9 / -1, 1 file)
```objc
-    button.accessibilityLabel = title;
+    if (title.length) {
+        button.accessibilityLabel = title;
+    } else if (acoAction.tooltip.length) {
+        button.accessibilityLabel = acoAction.tooltip;
+    }
```
Titled buttons are unchanged; untitled tooltip-only buttons now use the tooltip as their name.

## Validation (proxy CI — all green)
| Gate | Result |
|---|---|
| SDK Build Gate | ✅ `28272722282` |
| iOS-26 Toggle Validation | ✅ `28272722252` |
| Agent Validation Gate | ✅ `28272722265` |
| AXe A11y Overlay | ⚠️ infra-only fast-fail (brew tap); after-media run carries the brew fix |

## Accessibility evidence (AXe overlay pipeline)
- **Before:** dump `a11ymas_5536935_tooltip_elements.json` — **total = 1 element**; the entire card collapses to ONE button whose label aggregates every title (`title,Button with no title or tooltip,Button with...`). Annotated overlay shows the green focus box wrapping the whole card.
- **After (expected):** untitled buttons individually reachable, each named by its tooltip.
- Annotated overlay PNG + narration `.aiff` + `voiceover_demo.mp4` in AXe artifact (run `28265973966`), archived locally.

Fixes: AB#5536935
