### PR TITLE
fix(ios): expose interactive Icon (selectAction) to VoiceOver

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRIconRenderer.mm
@@ -69,6 +69,23 @@
     std::shared_ptr<BaseActionElement> selectAction = icon->GetSelectAction();
     ACOBaseActionElement *acoSelectAction = [ACOBaseActionElement getACOActionElementFromAdaptiveElement:selectAction];
     addSelectActionToView(acoConfig, acoSelectAction, rootView, wrappingView, viewGroup);
+
+    // An interactive icon (one with a selectAction) must be reachable and named for
+    // VoiceOver. Without this the icon is not an accessibility element, so screen
+    // reader users cannot find or activate it. Use the selectAction tooltip/title as
+    // the accessible name; fall back to the icon name. Decorative icons (no
+    // selectAction) are intentionally left non-accessible.
+    if (acoSelectAction) {
+        NSString *iconAccessibilityLabel = configureForAccessibilityLabel(acoSelectAction, nil);
+        if (!iconAccessibilityLabel.length) {
+            iconAccessibilityLabel = [NSString stringWithCString:icon->GetName().c_str() encoding:NSUTF8StringEncoding];
+        }
+        if (iconAccessibilityLabel.length) {
+            wrappingView.isAccessibilityElement = YES;
+            wrappingView.accessibilityLabel = iconAccessibilityLabel;
+            wrappingView.accessibilityTraits = UIAccessibilityTraitButton;
+        }
+    }
     
     // Configure visibility for the wrapping view so toggle visibility actions work correctly
     configVisibility(wrappingView, elem);


### PR DESCRIPTION
> **[PROXY-LANE DRAFT \u2014 review before graduation]** Staging PR on the `hggzm` fork (base `proxy/integration`) to confirm the fix + before/after evidence **before** a clean single-file PR is opened on `microsoft/Teams-AdaptiveCards-Mobile`. Not for merge here. **Evidence images are hosted as release assets (remote) \u2014 nothing is committed to the branch; the diff is the single source file.**

## Scenario
An **`Icon` with a `selectAction`** rendered no accessibility properties, so it was **not an accessibility element** \u2014 VoiceOver users could not find or activate it via swipe.

## Root cause
`ACRIconRenderer` sets zero accessibility properties on the icon/wrapping view, even when the icon is interactive (has a `selectAction`).

## Fix \u2014 `ACRIconRenderer.mm` (+17, **1 file**)
```objc
+    if (acoSelectAction) {
+        NSString *iconAccessibilityLabel = configureForAccessibilityLabel(acoSelectAction, nil);
+        if (!iconAccessibilityLabel.length) {
+            iconAccessibilityLabel = [NSString stringWithCString:icon->GetName().c_str() encoding:NSUTF8StringEncoding];
+        }
+        if (iconAccessibilityLabel.length) {
+            wrappingView.isAccessibilityElement = YES;
+            wrappingView.accessibilityLabel = iconAccessibilityLabel;
+            wrappingView.accessibilityTraits = UIAccessibilityTraitButton;
+        }
+    }
```
Reuses `configureForAccessibilityLabel` (same helper the Image renderer uses). **Decorative icons (no `selectAction`) remain non-accessible** \u2014 no new noise in the a11y tree.

## Validation (proxy CI \u2014 all green)
| Gate | Result |
|---|---|
| SDK Build Gate | \u2705 `28333246751` |
| iOS-26 Toggle Validation | \u2705 `28333246749` |
| Agent Validation Gate | \u2705 `28333246743` |

## Accessibility proof (AXe overlay pipeline) \u2014 **before \u2192 after**
Element-tree dump (VoiceOver-equivalent), same card (FluentIcon.RTL), fixed SDK:

| | a11y tree |
|---|---|
| **Before** (run `28265973966`) | 8 elements \u2014 **no icon/button elements at all** |
| **After** (run `28400225610`) | 10 elements incl. **`button \"Airplane\"`** + **`button \"Click me!, Icons can handle actions\"`** |

**Before**
![before](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5533268-icon-before.png)

**After** \u2014 box `[button] Airplane` shows the icon is now a focusable, named button:
![after](https://github.com/hggzm/Teams-AdaptiveCards-Mobile/releases/download/a11y-evidence-batch1/ac-5533268-icon-after.png)

VoiceOver narration `.aiff` + `voiceover_demo.mp4` are in the AXe artifacts and archived locally.

Fixes: AB#5533268
