### PR TITLE
fix(ios): announce CompoundButton as a single button to VoiceOver

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRCompoundButtonRenderer.mm
@@ -109,7 +109,21 @@
     std::shared_ptr<BaseActionElement> selectAction = compoundButton->GetSelectAction();
     ACOBaseActionElement *acoSelectAction = [ACOBaseActionElement getACOActionElementFromAdaptiveElement:selectAction];
     addSelectActionToView(acoConfig, acoSelectAction, rootView, compoundButtonView, viewGroup);
-    compoundButtonView.accessibilityLabel = @(compoundButton->getTitle().c_str());
+
+    // Expose the compound button as a single accessible button. Previously only the
+    // title was set as the label and no button trait was applied, so VoiceOver read
+    // the inner labels individually and never announced the control role. Combine
+    // the title, badge and description into one label and mark the view as a button.
+    compoundButtonView.isAccessibilityElement = YES;
+    NSMutableArray<NSString *> *compoundButtonLabelParts = [NSMutableArray array];
+    NSString *compoundButtonTitle = @(compoundButton->getTitle().c_str());
+    NSString *compoundButtonBadge = @(compoundButton->getBadge().c_str());
+    NSString *compoundButtonDescription = @(compoundButton->getDescription().c_str());
+    if (compoundButtonTitle.length) { [compoundButtonLabelParts addObject:compoundButtonTitle]; }
+    if (compoundButtonBadge.length) { [compoundButtonLabelParts addObject:compoundButtonBadge]; }
+    if (compoundButtonDescription.length) { [compoundButtonLabelParts addObject:compoundButtonDescription]; }
+    compoundButtonView.accessibilityLabel = [compoundButtonLabelParts componentsJoinedByString:@", "];
+    compoundButtonView.accessibilityTraits |= UIAccessibilityTraitButton;
     NSString *areaName = stringForCString(elem->GetAreaGridName());
     [viewGroup addArrangedSubview:compoundButtonView withAreaName:areaName];
     return compoundButtonView;


### PR DESCRIPTION
## Problem

`ACRCompoundButtonRenderer` set only the title as `accessibilityLabel` and applied no accessibility trait. The wrapping view was therefore never a single accessibility element, so VoiceOver walked the inner title/badge/description labels individually and never announced the control's role.

A screen-reader user hears three unrelated fragments and no indication that the thing is actuatable.

## Change

Mark the compound button as one accessibility element, build its label from the title, badge and description, and OR in `UIAccessibilityTraitButton` so traits already applied by `setAccessibilityTrait` (for example `UIAccessibilityTraitNotEnabled`) are preserved.

## Evidence

VoiceOver element scan of `samples/v1.5/Scenarios/CompoundButtonSample.json`, captured through the real UIAccessibility API (`XCUIElement`) on an iOS simulator, measured against an **otherwise identical control build** so the delta is attributable to this change alone:

| | Elements | Roles |
|---|---|---|
| control (without this change) | 12 | `{ text: 12 }` |
| with this change | **5** | `{ button: 5 }` |

Twelve loose text fragments become five buttons — one per compound button — each announced with its full content and the correct role. Reproduced across two independent run pairs (`31761865699`/`31763774960` and `31805356072`/`31805360808`).

### Annotated overlay

![CompoundButton accessibility overlay](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5532275_compoundbutton.png)

Raw per-element dump (label / value / role / bounds / what VoiceOver reads):
https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5532275_compoundbutton_elements.json

Full transcript for the run:
https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11y_transcript.json

## Scope

One file, `ACRCompoundButtonRenderer.mm`. No behaviour change for cards without a CompoundButton.

Work item: **AB#5532275** (A11yMAS, A11ySev2)
