### PR TITLE
fix(ios): apply the LTR semantic content attribute (configRtl tested RTL twice)

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/UtiliOS.mm
@@ -95,7 +95,7 @@ void configRtl(UIView *view, ACORenderContext *context)
         return;
     } else if (rtl == ACRRtlRTL) {
         view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
-    } else if (rtl == ACRRtlRTL) {
+    } else if (rtl == ACRRtlLTR) {
         view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
     }
 }


### PR DESCRIPTION
## Problem

`configRtl` has two branches testing the same condition:

```objc
} else if (rtl == ACRRtlRTL) {
    view.semanticContentAttribute = UISemanticContentAttributeForceRightToLeft;
} else if (rtl == ACRRtlRTL) {
    view.semanticContentAttribute = UISemanticContentAttributeForceLeftToRight;
}
```

The second branch is unreachable. `UISemanticContentAttributeForceLeftToRight` is never applied, so a card that explicitly requests LTR (`"rtl": false`) does not get LTR semantics forced and instead inherits whatever the surrounding context provides.

Still present on `main` as of this PR.

## Change

Test `ACRRtlLTR` in the second branch, which is clearly what it was meant to do.

One character. No behaviour change for `ACRRtlNone` or `ACRRtlRTL` — the only newly reachable path is the one always intended for `ACRRtlLTR`.

## Evidence

**None from the accessibility pipeline, and I would rather say so than overstate it.**

The defect is a self-evident unreachable branch, verified present on `main` by reading the current source. But the `AdaptiveCard.Rtl.False.json` scenario could not be captured in a control run, so there is no before/after element scan to attach. The scenario capture is blocked on a separate test-harness issue, not on this change.

Sending on the strength of the code reading. Happy to hold until a matched scan is available if reviewers prefer.

Work item: **AB#5536877** (A11yMAS, A11ySev2)
Supersedes #644, which carried the same fix on a fork branch and therefore never ran CI.
