### PR TITLE
fix(ios): expose RichTextBlock selectAction links to VoiceOver

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRRichTextBlockRenderer.mm
@@ -77,6 +77,9 @@
     lab.layoutManager.usesFontLeading = false;
 
     NSMutableAttributedString *content = [[NSMutableAttributedString alloc] init];
+    // Tracks whether any TextRun contributed a link. Declared out here because the
+    // accessibility decision at the end of this method is outside the rootView scope.
+    BOOL containsSelectActionLink = NO;
     if (rootView) {
         NSMutableDictionary *textMap = [rootView getTextMap];
         NSObject<ACRIFeatureFlagResolver> *featureFlagResolver = [[ACRRegistration getInstance] getFeatureFlagResolver];
@@ -160,6 +163,7 @@
                                 [textRunContent addAttribute:NSLinkAttributeName
                                                        value:target
                                                        range:selectActionRange];
+                                containsSelectActionLink = YES;
 
                                 if (!hasGestureRecognizerAdded) {
                                     [ACRTapGestureRecognizerFactory
@@ -280,6 +284,14 @@
     lab.attributedText = content;
     if ([content.string stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceCharacterSet].length == 0) {
         lab.accessibilityValue = @"";
+        lab.isAccessibilityElement = NO;
+    } else if (containsSelectActionLink) {
+        // This block contains links. Marking the text view as a single accessibility
+        // element would collapse it into one static-text node and destroy VoiceOver link
+        // navigation - the links inside become unreachable by swipe, which is the whole
+        // reason `editable` is forced to YES further up. UITextView exposes
+        // NSLinkAttributeName ranges as their own accessibility elements only while it is
+        // not itself a leaf.
         lab.isAccessibilityElement = NO;
     } else {
         lab.isAccessibilityElement = YES;


### PR DESCRIPTION
Stacked on #68 so the diff here is exactly the renderer change: **1 file, +12 lines**.

## The defect

`InputLabel.json` contains four RichTextBlocks, each with a `Click here for action.`
TextRun carrying `Action.OpenUrl`. In the rendered accessibility tree there is **no node
of role link or button anywhere** — only `textView`, `text` and `textField`.

Where a RichTextBlock is bound to an input via `labelFor`, its entire text including the
link is copied into the text field's accessibility label:

```
[textField] id=textInputId00
            "RichTextBlock 4 This is the first text run.  Click here for action.
             This is the second text run.  \nRequired"
```

So a VoiceOver user hears "Click here for action" as part of a sentence and has no way to
reach or activate it.

## The change

`ACRRichTextBlockRenderer.mm` tracks whether any TextRun contributed an
`NSLinkAttributeName`, and if so leaves the text view as a non-leaf so `UITextView`
exposes its link ranges as their own accessibility elements.

## Evidence status

**Pending.** The earlier control/fix pair showed a zero delta, but that pair was measured
by a scanner that did not query `XCUIElementTypeLink` — see the parent PR. The comparison
is being re-run against the repaired scanner:

- control `proxy/fix-a11y-pipeline-diagnostics`
- fix `proxy/fix-richtext-a11y-instrumented` (this branch, same tree +12 lines)

I will post the element census and annotated screenshots here before proposing this
upstream. If the delta is still zero against a scanner that *can* represent the outcome,
this branch should be closed rather than merged.

