### PR TITLE
fix(ios): restore VoiceOver focus after the overflow menu is cancelled

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRActionOverflowRenderer.mm
@@ -46,6 +46,8 @@
         ACRTargetBuilderDirector *director = [rootView getActionsTargetBuilderDirector];
         ACRRenderingStatus status = buildTargetForButton(director, acoElem, button, &target);
         if (ACRRenderingStatus::ACROk == status) {
+            // So the menu can hand VoiceOver focus back to this button on dismissal.
+            target.accessibilityFocusAnchor = button;
             [superview addTarget:target];
             // to support Action.ShowCard in menu item action, this line is required
             [target setInputs:inputs superview:superview];

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.h
@@ -31,4 +31,9 @@
 
 @property (readonly) NSArray<ACROverflowMenuItem *> *menuItems;
 
+/// The control that opened the overflow menu. VoiceOver focus is returned here when the
+/// menu is dismissed, so the user lands back where they were instead of at the top of
+/// the screen.
+@property (nonatomic, weak) UIView *accessibilityFocusAnchor;
+
 @end

--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACROverflowTarget.mm
@@ -242,9 +242,20 @@ NSString *const ACROverflowTargetIsRootLevelKey = @"isAtRootLevel";
         }
     }
 
+    // Dismissing the sheet has to say where focus goes. With a nil handler nothing posts
+    // an accessibility notification, so VoiceOver falls back to the platform default and
+    // the user loses their place instead of returning to the control they opened the menu
+    // from. ACRShowCardTarget already handles the equivalent case this way.
+    __weak __typeof(self) weakSelf = self;
     [_alert addAction:[UIAlertAction actionWithTitle:@"Cancel"
                                                style:UIAlertActionStyleCancel
-                                             handler:nil]];
+                                             handler:^(UIAlertAction *action) {
+                                                 __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                                 UIView *anchor = strongSelf.accessibilityFocusAnchor;
+                                                 if (anchor) {
+                                                     UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, anchor);
+                                                 }
+                                             }]];
 }
 
 - (void)setInputs:(NSMutableArray *)inputs


### PR DESCRIPTION
## Problem

`ACROverflowTarget` presents the overflow action sheet with `handler:nil` on its Cancel action, and posts no accessibility notification when the sheet is dismissed. Nothing tells iOS where VoiceOver focus should land, so it falls back to the platform default — the top of the card — instead of the control the user opened the menu from.

`ACRShowCardTarget` already handles the equivalent case by posting `UIAccessibilityLayoutChangedNotification` with an explicit anchor view. This applies that same established pattern to the overflow menu.

## Change

- `ACROverflowTarget` gains a weak `accessibilityFocusAnchor` property.
- `ACRActionOverflowRenderer` sets it to the button that opened the menu.
- The Cancel handler posts `UIAccessibilityLayoutChangedNotification` against that anchor.

Weak, so the target never keeps the button alive. Nil-checked, so a released anchor posts nothing rather than an unanchored notification.

Three files, +19/−1. No behaviour change for cards without an overflow menu.

## Evidence — and what it does not cover

VoiceOver element scan of the overflow scenario across three states, captured through the real `UIAccessibility` API (`XCUIElement`) on an iOS simulator:

| state | elements | hittable buttons |
|---|---|---|
| before open | 41 | 8 |
| menu open | 41 | **0** |
| after cancel | 41 | 8 |

Hittable buttons going `8 → 0 → 8` confirms the sheet really is presented and really is dismissed. The `after cancel` tree is byte-identical to `before open`, so this change introduces no regression to the card's accessibility tree.

**What this does not show.** The harness records `label / role / frame / isHittable / isEnabled / isSelected / value`. It does **not** record which element holds VoiceOver focus, and the action sheet is presented in a separate `UIWindow` that the scan does not traverse — note `Cancel` never appears in any of the three dumps.

So the focus restoration itself is argued from code inspection and from the existing `ACRShowCardTarget` precedent — it is **not** measured here. Calling that out plainly rather than implying a measurement that was not taken. Confirming it needs VoiceOver driven on a physical device.

### Annotated overlays

Before opening the menu:

![before](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5536765_actionmode_cancel_before.png)

Menu open:

![open](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5536765_actionmode_cancel_after.png)

After cancel:

![after dismiss](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/annotated_a11ymas_5536765_actionmode_cancel_afterdismiss.png)

Raw per-element dumps:
- [before](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5536765_actionmode_cancel_before_elements.json)
- [open](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5536765_actionmode_cancel_after_elements.json)
- [after cancel](https://hggzm.github.io/Teams-AdaptiveCards-Mobile/a11ymas_5536765_actionmode_cancel_afterdismiss_elements.json)

## Review note

This branch is shaped exactly as it will be submitted upstream: cut from `upstream/main` (`5a5cad0f5`), carrying only the three SDK files, with none of the proxy harness or CI. The upstream PR will be this same commit pushed to `microsoft/Teams-AdaptiveCards-Mobile` as `users/hggzm/clean/fix-overflow-cancel-focus-5536765`, targeting `main`.

Work item: **AB#5536765** (A11yMAS)
