### PR TITLE
fix(ios): name icon-only inline action buttons from their tooltip

### DIFF
--- a/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
+++ b/source/ios/AdaptiveCards/AdaptiveCards/AdaptiveCards/ACRInputRenderer.mm
@@ -192,7 +192,16 @@
         NSString *key = [NSString stringWithCString:action->GetIconUrl(ACTheme(rootView.theme)).c_str() encoding:[NSString defaultCStringEncoding]];
         UIImage *img = imageViewMap[key];
         button.iconPlacement = ACRNoTitle;
-        button.accessibilityLabel = title;
+        // An icon-only inline action carries no title, so this assigned an empty string and
+        // left the button with no accessible name at all - VoiceOver reaches a control it
+        // cannot announce or describe. The card does name it, through the action's tooltip,
+        // which is the same text a sighted user gets on hover.
+        //
+        // This is the mirror of the rule further down that promotes the title to the tooltip
+        // when an icon button has a title but no tooltip; title and tooltip are already
+        // treated as interchangeable naming sources for these buttons.
+        NSString *tooltip = [NSString stringWithCString:action->GetTooltip().c_str() encoding:NSUTF8StringEncoding];
+        button.accessibilityLabel = title.length ? title : tooltip;
 
         if (img) {
             UIImageView *iconView = [[ACRUIImageView alloc] init];


### PR DESCRIPTION
## Problem

`ACRInputRenderer` names an inline action button from the action's **title** only:

```objc
NSString *title = [NSString stringWithCString:action->GetTitle().c_str() ...];
button.accessibilityLabel = title;
```

An icon-only inline action has no title, so `GetTitle()` returns empty and the button is left with an empty accessibility label — a control VoiceOver can reach but cannot announce or describe. The user encounters an actionable button with no name.

`samples/v1.3/Elements/Input.Text.InlineAction.json` contains exactly this: an `Action.Submit` with an `iconUrl` and `"tooltip": "Send"`, and no title.

## Change

Fall back to the action's tooltip when there is no title — the same text a sighted user gets on hover, and the author's own words for the control.

This is the **mirror of a rule that already exists** twelve lines below, which promotes the title to the tooltip when an icon button has a title but no tooltip:

```objc
if (!acoSelectAction.tooltip && acoSelectAction.title && key.length) {
    acoSelectAction.tooltip = acoSelectAction.title;
}
```

Title and tooltip are already treated as interchangeable naming sources for these buttons; this covers the other direction. One file, +10/-1.

## Evidence

VoiceOver element scan of `samples/v1.3/Elements/Input.Text.InlineAction.json`, captured through the real `UIAccessibility` API (`XCUIElement`) on an iOS simulator, against an **otherwise identical control build** — same harness commit, same card, one file different.

| | elements | roles |
|---|---|---|
| control (without this change) | 4 | `{ textField: 2, link: 1, text: 1 }` |
| with this change | **5** | `{ textField: 2, **button: 1**, link: 1, text: 1 }` |

The new element is `[button] 'Send'`. Every other element is byte-identical, so the delta is attributable to this change alone.

```
control                          with this change
[textField] 'Text input ...'     [textField] 'Text input ...'
                                 [button]    'Send'          <-- was unnamed, therefore absent
[textField] 'Text input ... no icon'  [textField] 'Text input ... no icon'
[link]      'Reply'              [link]      'Reply'
[text]      'Reply'              [text]      'Reply'
```

Note on why the button was *absent* rather than present-and-blank: the scanner skips elements whose accessibility label is empty, which is precisely the condition this fixes. A control with no name is invisible to a name-based scan — and to a screen-reader user trying to find it.

Control run `32908672373`, fix run `32908676014`, both `evidence_usable: true`.

### Annotated overlays

Before — no named button between the two inputs:

![before](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539230/before_annotated.png)

After — the icon button is named and enumerated:

![after](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539230/after_annotated.png)

Raw per-element dumps:
[before](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539230/before_elements.json) ·
[after](https://raw.githubusercontent.com/hggzm/Teams-AdaptiveCards-Mobile/proxy/evidence-assets/5539230/after_elements.json)

## Out of scope, but observed

`Reply` appears twice in both control and fix — once as `link` and once as `text`. That is a separate duplicate-announcement defect in the titled inline action path, unchanged by this PR and deliberately not bundled into it.

## Review note

This branch is shaped exactly as it will be submitted upstream: cut from `upstream/main` (`5a5cad0f5`), carrying only the one SDK file, with none of the proxy harness or CI. The upstream PR will be this same commit pushed to `microsoft/Teams-AdaptiveCards-Mobile` as `users/hggzm/clean/fix-inlineaction-tooltip-name`, targeting `main`.

Work item: **AB#5539230** (A11yMAS)
